### PR TITLE
Enable Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 sudo: false
 python:
+- '2.6'
 - '2.7'
 - '3.3'
 - '3.4'

--- a/dotenv.py
+++ b/dotenv.py
@@ -2,7 +2,10 @@
 
 import os
 import warnings
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 
 import click
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     py_modules=['dotenv'],
     install_requires=[
         'click>=5.0',
+        'ordereddict'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Support Python 2.6, since it's trivial.