### PR TITLE
Stripping keys and values whitespaces

### DIFF
--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -89,6 +89,8 @@ def parse_dotenv(dotenv_path):
             if not line or line.startswith('#') or '=' not in line:
                 continue
             k, v = line.split('=', 1)
+            k = k.strip()
+            v = v.strip()
             if len(v) > 0:
                 quoted = v[0] == v[len(v) - 1] == '"'
 


### PR DESCRIPTION
If .env has some line like

```VAR = VALUE```

the original code will parse and populate `os.environ` with

```'VAR ': ' VALUE'    # note the whitespaces```

I think it's cheap enough to clean these whitespaces, guaranteeing consistence between people's common sense.