### PR TITLE
Fix dotenv_as_dict value unpacking in cli:list()

### DIFF
--- a/dotenv/cli.py
+++ b/dotenv/cli.py
@@ -26,7 +26,7 @@ def list(ctx):
     '''Display all the stored key/value.'''
     file = ctx.obj['FILE']
     dotenv_as_dict = dotenv_values(file)
-    for k, v in dotenv_as_dict:
+    for k, v in dotenv_as_dict.items():
         click.echo('%s="%s"' % (k, v))
 
 


### PR DESCRIPTION
The for-loop in `dotenv.cli:list()` that iterates through `dotenv_as_dict` is missing a call to `items()`, which causes a `too many values to unpack` `ValueError`.

Relevant traceback call:

```
  File ".../dotenv/cli.py", line 29, in list
    for k, v in dotenv_as_dict:
ValueError: too many values to unpack (expected 2)
```

This issue started happening in version 0.6.0. The previous version, 0.5.1, is not affected.
