### PR TITLE
Allow multiline values

### DIFF
--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -93,15 +93,7 @@ def dotenv_values(dotenv_path):
 
 def parse_dotenv(dotenv_path):
     with open(dotenv_path) as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith('#') or '=' not in line:
-                continue
-            k, v = line.split('=', 1)
-
-            # Remove any leading and trailing spaces in key, value
-            k, v = k.strip(), v.strip()
-
+        for k, v in re.findall('^\s*(\w*)\s*=\s*("[^"]*"|[^\s]*)\s*$', f.read(), flags=re.MULTILINE):
             if len(v) > 0:
                 quoted = v[0] == v[len(v) - 1] == '"'
 


### PR DESCRIPTION
This PR adds functionality for multiline strings to dotenv. It replaces the line-by-line traversal by a regex, which finds all multiline matches as well. 
