### PR TITLE
Add `PYTHONPATH` support

### DIFF
--- a/dotenv/cli.py
+++ b/dotenv/cli.py
@@ -93,5 +93,6 @@ def get_cli_string(path=None, action=None, key=None, value=None):
 
     return ' '.join(command).strip()
 
+
 if __name__ == "__main__":
     cli()

--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -25,6 +25,9 @@ def load_dotenv(dotenv_path):
         return None
     for k, v in dotenv_values(dotenv_path).items():
         os.environ.setdefault(k, v)
+        # Update evaluated sys.path
+        if k == 'PYTHONPATH':
+            sys.path = v.split(':') + sys.path
     return True
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 # -*- coding: utf8 -*-
 import os
+import sys
 import pytest
 import tempfile
 import warnings
@@ -68,4 +69,18 @@ def test_load_dotenv(cli):
         assert success
         assert 'DOTENV' in os.environ
         assert os.environ['DOTENV'] == 'WORKS'
+        sh.rm(dotenv_path)
+
+
+def test_load_dotenv_pythonpath_support(cli):
+    dotenv_path = '.test_load_dotenv'
+    test_path_1 = '/my/first/test/path'
+    test_path_2 = './some/second/test/path'
+    with cli.isolated_filesystem():
+        sh.touch(dotenv_path)
+        set_key(dotenv_path, 'PYTHONPATH', '{}:{}'.format(test_path_1, test_path_2))
+        success = load_dotenv(dotenv_path)
+        assert success
+        assert test_path_1 == sys.path[0]
+        assert test_path_2 == sys.path[1]
         sh.rm(dotenv_path)


### PR DESCRIPTION
I found it convenient in my project to be able to set a `PYTHONPATH` environment variable in the `.env` config, and to let `dotenv` automatically prepend it to the `sys.path` (constructed prior to any possible `dotenv` loading).

It could probably benefit some other people, so here it is :)