### PR TITLE
fix utf-8 encoding when reading the readme.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
 
-with open('README.rst', encoding="utf8") as readme_file:
-    readme = readme_file.read()
+import sys
+if sys.version_info[0] > 2:
+	with open('README.rst', encoding="utf8") as readme_file:
+		readme = readme_file.read()
+else:
+	import io
+	with io.open('README.rst', encoding="utf8") as readme_file:
+		readme = readme_file.read()
 
 setup(
     name="python-dotenv",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
 
-with open('README.rst') as readme_file:
+with open('README.rst', encoding="utf8") as readme_file:
     readme = readme_file.read()
 
 setup(


### PR DESCRIPTION
fixing this encoding resolves the installation issue #46 in Windows.