### PR TITLE
Allow quote mode to be specified in get_cli_string

### DIFF
--- a/dotenv/cli.py
+++ b/dotenv/cli.py
@@ -72,13 +72,15 @@ def unset(ctx, key):
         exit(1)
 
 
-def get_cli_string(path=None, action=None, key=None, value=None):
+def get_cli_string(path=None, action=None, key=None, value=None, quote=None):
     """Returns a string suitable for running as a shell script.
 
     Useful for converting a arguments passed to a fabric task
     to be passed to a `local` or `run` command.
     """
     command = ['dotenv']
+    if quote:
+        command.append('-q %s' % quote)
     if path:
         command.append('-f %s' % path)
     if action:


### PR DESCRIPTION
The title says it all. I use python-dotenv with Fabric and want to be able to control the  quote mode from "get_cli_string".

Thanks for an awesome library :-)