### PR TITLE
add-run-command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,8 +132,10 @@ update your settings on remote server, handy isn't it!
     Commands:
       get    Retrive the value for the given key.
       list   Display all the stored key/value.
+      run    Run commandline with specified .env file.
       set    Store the given key/value.
       unset  Removes the given key.
+
 
 iPython Support
 ---------------

--- a/dotenv/cli.py
+++ b/dotenv/cli.py
@@ -5,6 +5,7 @@ import click
 from .main import get_key, dotenv_values, set_key, unset_key
 from subprocess import call
 
+
 @click.group()
 @click.option('-f', '--file', default=os.path.join(os.getcwd(), '.env'),
               type=click.Path(exists=True),

--- a/dotenv/cli.py
+++ b/dotenv/cli.py
@@ -3,7 +3,7 @@ import os
 import click
 
 from .main import get_key, dotenv_values, set_key, unset_key
-
+from subprocess import call
 
 @click.group()
 @click.option('-f', '--file', default=os.path.join(os.getcwd(), '.env'),
@@ -28,6 +28,22 @@ def list(ctx):
     dotenv_as_dict = dotenv_values(file)
     for k, v in dotenv_as_dict.items():
         click.echo('%s="%s"' % (k, v))
+
+
+@cli.command(context_settings=dict(
+    ignore_unknown_options=True,
+))
+@click.pass_context
+@click.argument('commandline', nargs=-1, type=click.UNPROCESSED)
+def run(ctx, commandline):
+    '''Run commandline with specified .env file.'''
+    if commandline:
+        args = map(str, commandline)
+        file = ctx.obj['FILE']
+        dotenv_as_dict = dotenv_values(file)
+        call(args, env=dotenv_as_dict)
+    else:
+        click.echo(ctx.get_help())
 
 
 @cli.command()

--- a/dotenv/cli.py
+++ b/dotenv/cli.py
@@ -39,9 +39,9 @@ def list(ctx):
 def run(ctx, commandline):
     '''Run commandline with specified .env file.'''
     if commandline:
-        args = map(str, commandline)
+        args = [str(arg) for arg in commandline]
         file = ctx.obj['FILE']
-        dotenv_as_dict = dotenv_values(file)
+        dotenv_as_dict = dict(dotenv_values(file))
         call(args, env=dotenv_as_dict)
     else:
         click.echo(ctx.get_help())

--- a/dotenv/cli.py
+++ b/dotenv/cli.py
@@ -2,7 +2,7 @@ import os
 
 import click
 
-from .main import get_key, dotenv_values, set_key, unset_key
+from .main import get_key, dotenv_values, set_key, unset_key, load_dotenv
 from subprocess import call
 
 
@@ -41,8 +41,8 @@ def run(ctx, commandline):
     if commandline:
         args = [str(arg) for arg in commandline]
         file = ctx.obj['FILE']
-        dotenv_as_dict = dict(dotenv_values(file))
-        call(args, env=dotenv_as_dict)
+        load_dotenv(file)
+        call(args, env=os.environ)
     else:
         click.echo(ctx.get_help())
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ bumpversion
 wheel
 pytest-cov
 pytest-flake8
+mock

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,10 +38,15 @@ def test_list_wo_file(cli):
 
 def test_run(cli, dotenv_file):
     with mock.patch("dotenv.cli.call") as call_mock:
-        dotenv.set_key(dotenv_file, 'HELLO', 'WORLD')
-        result = cli.invoke(dotenv.cli.cli, ['--file', dotenv_file, 'run', 'python', '-m', 'json.tool'])
-        assert result.exit_code == 0, result.output
-        call_mock.assert_called_with(['python', '-m', 'json.tool'], env={"HELLO": "WORLD"})
+        with mock.patch("os.environ", {"foo": "bar"}):
+            dotenv.set_key(dotenv_file, 'HELLO', 'WORLD')
+
+            result = cli.invoke(dotenv.cli.cli, [
+                '--file', dotenv_file, 'run', 'python', '-m', 'json.tool'])
+            assert result.exit_code == 0, result.output
+            call_mock.assert_called_with(
+                ['python', '-m', 'json.tool'],
+                env={"foo": "bar", "HELLO": "WORLD"})
 
 
 def test_key_value_without_quotes():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,8 @@
 from os import environ
 from os.path import dirname, join
 
+import mock
+
 import dotenv
 
 import sh
@@ -32,6 +34,14 @@ def test_list_wo_file(cli):
     result = cli.invoke(dotenv.cli.cli, ['--file', 'doesnotexists', 'list'])
     assert result.exit_code == 2, result.output
     assert 'Invalid value for "-f"' in result.output
+
+
+def test_run(cli, dotenv_file):
+    with mock.patch("dotenv.cli.call") as call_mock:
+        dotenv.set_key(dotenv_file, 'HELLO', 'WORLD')
+        result = cli.invoke(dotenv.cli.cli, ['--file', dotenv_file, 'run', 'python', '-m', 'json.tool'])
+        assert result.exit_code == 0, result.output
+        call_mock.assert_called_with(['python', '-m', 'json.tool'], env={"HELLO": "WORLD"})
 
 
 def test_key_value_without_quotes():


### PR DESCRIPTION
I think it would be neat if the `dotenv` cli tool had an option to run a given commandline WITH the environment vars sourced from specified file, like a RUNNER.

```
# using the env command to print out env
echo "foo=bar" > .env
$ dotenv -f .env env 
foo=bar
```