### PR TITLE
Naive single quotes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,7 +126,8 @@ update your settings on remote server, handy isn't it!
                                       file in current working directory.
       -q, --quote [always|never|auto]
                                       Whether to quote or not the variable values.
-                                      Default mode is always.
+                                      Default mode is always. This does not affect
+                                      parsing.
       --help                          Show this message and exit.
 
     Commands:

--- a/dotenv/cli.py
+++ b/dotenv/cli.py
@@ -11,7 +11,7 @@ from .main import get_key, dotenv_values, set_key, unset_key
               help="Location of the .env file, defaults to .env file in current working directory.")
 @click.option('-q', '--quote', default='always',
               type=click.Choice(['always', 'never', 'auto']),
-              help="Whether to quote or not the variable values. Default mode is always.")
+              help="Whether to quote or not the variable values. Default mode is always. This does not affect parsing.")
 @click.pass_context
 def cli(ctx, file, quote):
     '''This script is used to set, get or unset values from a .env file.'''

--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -103,7 +103,7 @@ def parse_dotenv(dotenv_path):
             k, v = k.strip(), v.strip()
 
             if len(v) > 0:
-                quoted = v[0] == v[len(v) - 1] == '"'
+                quoted = v[0] == v[len(v) - 1] in ['"', "'"]
 
                 if quoted:
                     v = decode_escaped(v[1:-1])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,18 @@ def test_key_value_without_quotes():
     sh.rm(dotenv_path)
 
 
+def test_value_with_quotes():
+    with open(dotenv_path, 'w') as f:
+        f.write('TEST="two words"\n')
+    assert dotenv.get_key(dotenv_path, 'TEST') == 'two words'
+    sh.rm(dotenv_path)
+
+    with open(dotenv_path, 'w') as f:
+        f.write("TEST='two words'\n")
+    assert dotenv.get_key(dotenv_path, 'TEST') == 'two words'
+    sh.rm(dotenv_path)
+
+
 def test_unset():
     sh.touch(dotenv_path)
     success, key_to_set, value_to_set = dotenv.set_key(dotenv_path, 'HELLO', 'WORLD')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,6 +104,13 @@ def test_get_key_with_interpolation(cli):
         dotenv.set_key(dotenv_path, 'FOO', '${HELLO}')
         dotenv.set_key(dotenv_path, 'BAR', 'CONCATENATED_${HELLO}_POSIX_VAR')
 
+        lines = list(open(dotenv_path, "r").readlines())
+        assert lines == [
+            'HELLO="WORLD"\n',
+            'FOO="${HELLO}"\n',
+            'BAR="CONCATENATED_${HELLO}_POSIX_VAR"\n',
+        ]
+
         # test replace from variable in file
         stored_value = dotenv.get_key(dotenv_path, 'FOO')
         assert stored_value == 'WORLD'


### PR DESCRIPTION
This fixes #35 

Note, that this is still far from an SH-compatible parser, but this at least fixes this particular issue.

To be an SH-compatible parser, these kinds of things would have to be fixed:

- `HELLO=WORLD` shoud be treated differently from `HELLO= WORLD`
- `HELLO=${WORLD}` should be treated differently from `HELLO='${WORLD}'`
- The parsing of a POSIX variable should take a previous POSIX variable in precedence over an environment variable.
- And so on.