### PR TITLE
Disable ".env not found" warning by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,9 @@ Add the following code to your ``settings.py``
     dotenv_path = join(dirname(__file__), '.env')
     load_dotenv(dotenv_path)
 
+    # OR, the same with increased verbosity:
+    load_dotenv(dotenv_path, verbose=True)
+
 Alternatively, you can use ``find_dotenv()`` method that will try to find a
 ``.env`` file by (a) guessing where to start using ``__file__`` or the working
 directory -- allowing this to work in non-file contexts such as IPython notebooks

--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -16,12 +16,13 @@ def decode_escaped(escaped):
     return __escape_decoder(escaped)[0]
 
 
-def load_dotenv(dotenv_path):
+def load_dotenv(dotenv_path, verbose=False):
     """
     Read a .env file and load into os.environ.
     """
     if not os.path.exists(dotenv_path):
-        warnings.warn("Not loading %s - it doesn't exist." % dotenv_path)
+        if verbose:
+            warnings.warn("Not loading %s - it doesn't exist." % dotenv_path)
         return None
     for k, v in dotenv_values(dotenv_path).items():
         os.environ.setdefault(k, v)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv, find_dotenv, set_key
 
 def test_warns_if_file_does_not_exist():
     with warnings.catch_warnings(record=True) as w:
-        load_dotenv('.does_not_exist')
+        load_dotenv('.does_not_exist', verbose=True)
 
         assert len(w) == 1
         assert w[0].category is UserWarning


### PR DESCRIPTION
Because this warning _scares_ me and our team more often than _helps_ us.

Probably, similar changes should be applied to other functions.

### Added

`verbose` option for `load_dotenv`, which will log any error messages

### Changed

Warning `File .env not found` disabled by default.

Several investigations are here: motdotla/dotenv#154 (be careful, NodeJS thread)