### PR TITLE
Add --version option for the CLI

### DIFF
--- a/dotenv/__init__.py
+++ b/dotenv/__init__.py
@@ -1,3 +1,5 @@
+__version__ = '0.6.4'
+
 from .cli import get_cli_string
 from .main import load_dotenv, get_key, set_key, unset_key, find_dotenv
 from .ipython import load_ipython_extension

--- a/dotenv/cli.py
+++ b/dotenv/cli.py
@@ -2,6 +2,7 @@ import os
 
 import click
 
+from . import __version__
 from .main import get_key, dotenv_values, set_key, unset_key
 
 
@@ -12,6 +13,7 @@ from .main import get_key, dotenv_values, set_key, unset_key
 @click.option('-q', '--quote', default='always',
               type=click.Choice(['always', 'never', 'auto']),
               help="Whether to quote or not the variable values. Default mode is always. This does not affect parsing.")
+@click.version_option(version=__version__)
 @click.pass_context
 def cli(ctx, file, quote):
     '''This script is used to set, get or unset values from a .env file.'''

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
-
+from dotenv import __version__
 # https://github.com/theskumar/python-dotenv/issues/45#issuecomment-277135416
 try:
     with open('README.rst') as readme_file:
@@ -12,7 +12,7 @@ setup(
     name="python-dotenv",
     description="Add .env support to your django/flask apps in development and deployments",
     long_description=readme,
-    version="0.6.4",
+    version=__version__,
     author="Saurabh Kumar",
     author_email="me+github@saurabh-kumar.com",
     url="http://github.com/theskumar/python-dotenv",


### PR DESCRIPTION
This PR will add `--version` to the CLI like this:

```bash
 ➜ dotenv --version
dotenv, version 0.6.4
```

```python
 ➜ python
>>> import dotenv
>>> dotenv.__version__
'0.6.4'
```


The `dotenv --help` would display this:
```
➜ dotenv --help   
Usage: dotenv [OPTIONS] COMMAND [ARGS]...

  This script is used to set, get or unset values from a .env file.

Options:
  -f, --file PATH                 Location of the .env file, defaults to .env
                                  file in current working directory.
  -q, --quote [always|never|auto]
                                  Whether to quote or not the variable values.
                                  Default mode is always. This does not affect
                                  parsing.
  --version                       Show the version and exit.
  --help                          Show this message and exit.

Commands:
  get    Retrive the value for the given key.
  list   Display all the stored key/value.
  set    Store the given key/value.
  unset  Removes the given key.

```


Resolves #56.