### PR TITLE
Added support for special characters

### DIFF
--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -100,7 +100,7 @@ def parse_dotenv(dotenv_path):
             k, v = line.split('=', 1)
 
             # Remove any leading and trailing spaces in key, value
-            k, v = k.strip(), v.strip()
+            k, v = k.strip(), v.strip().encode('unicode-escape').decode('ascii')
 
             if len(v) > 0:
                 quoted = v[0] == v[len(v) - 1] in ['"', "'"]
@@ -114,7 +114,7 @@ def parse_dotenv(dotenv_path):
 def resolve_nested_variables(values):
     def _replacement(name):
         """
-        get appropiate value for a variable name.
+        get appropriate value for a variable name.
         first search in environ, if not found,
         then look into the dotenv variables
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,18 @@ def test_value_with_quotes():
     sh.rm(dotenv_path)
 
 
+def test_value_with_special_characters():
+    with open(dotenv_path, 'w') as f:
+        f.write(r'TEST="}=&~{,(\5%{&;"')
+    assert dotenv.get_key(dotenv_path, 'TEST') == r'}=&~{,(\5%{&;'
+    sh.rm(dotenv_path)
+
+    with open(dotenv_path, 'w') as f:
+        f.write(r"TEST='}=&~{,(\5%{&;'")
+    assert dotenv.get_key(dotenv_path, 'TEST') == r'}=&~{,(\5%{&;'
+    sh.rm(dotenv_path)
+
+
 def test_unset():
     sh.touch(dotenv_path)
     success, key_to_set, value_to_set = dotenv.set_key(dotenv_path, 'HELLO', 'WORLD')


### PR DESCRIPTION
Without this changes the new test that I added fail. So for example, you have in your `.env` password with special characters:

```
PASSWORD="}=&~{,(\5%{&;"
```

But using package it return: `}=&~{,(%{&;` (Missing `\5`)