### PR TITLE
Cut shell commands from key

### DIFF
--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -100,7 +100,9 @@ def parse_dotenv(dotenv_path):
             k, v = line.split('=', 1)
 
             # Remove any leading and trailing spaces in key, value
-            k, v = k.strip(), v.strip().encode('unicode-escape').decode('ascii')
+            # Remove export, set -e (any shell commands) in key
+            k = k.strip().split(' ')[-1]
+            v = v.strip().encode('unicode-escape').decode('ascii')
 
             if len(v) > 0:
                 quoted = v[0] == v[len(v) - 1] in ['"', "'"]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -62,7 +62,7 @@ def test_load_dotenv(cli):
     dotenv_path = '.test_load_dotenv'
     with cli.isolated_filesystem():
         sh.touch(dotenv_path)
-        set_key(dotenv_path, 'DOTENV', 'WORKS')
+        set_key(dotenv_path, 'export DOTENV', 'WORKS')
         assert 'DOTENV' not in os.environ
         success = load_dotenv(dotenv_path)
         assert success


### PR DESCRIPTION
Bash "export", Fish "set -e" or any other break dotenv functionality:
```
#.env
export KEY=value
```

```sh
$ source .env
$ echo $KEY
value

$ dotenv get KEY
/home/vganzin/github/python-dotenv/dotenv/main.py:45: UserWarning: key KEY not found in /home/vganzin/work/pipeline/.env.
  warnings.warn("key %s not found in %s." % (key_to_get, dotenv_path))

$ dotenv get "export KEY"
value
```

