### PR TITLE
Orm like setting parser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -168,6 +168,44 @@ You can use dotenv with iPython. You can either let the dotenv search for .env w
     %dotenv -v
 
 
+ORM-like setting module
+-----------------------
+
+An ORM-like setting-module has been add for better user-experience while using environment variables as config.
+
+.. code:: python
+
+    # We assume INT_EXAMPLE=1, STRING_EXAMPLE=HI
+    from dotenv import orm
+
+    class Model(orm.EnvModel):
+        example = orm.IntField(
+            "INT_EXAMPLE",
+            required=False,
+            default=None,
+        )
+
+    settings = Model()
+
+    print(type(settings.example.value))     # int
+    print(settings.example.name)        # INT_EXAMPLE
+    print(settings.is_valid())          # True
+
+    # update (if new env is set)
+    settings.update()
+
+    # visit errors
+    print(settings.errors)
+
+
+Current supported types:
+
+-  `StringField`
+-  `IntField`
+-  `FloatField`
+-  `BooleanField`
+
+
 Setting config on remote servers
 --------------------------------
 

--- a/dotenv/orm.py
+++ b/dotenv/orm.py
@@ -149,4 +149,3 @@ class EnvModel(object):
         Update values from env again.
         """
         self._build_data()
-

--- a/dotenv/orm.py
+++ b/dotenv/orm.py
@@ -1,0 +1,152 @@
+import os
+
+
+class ConvertError(ValueError):
+
+    def __init__(self, *args, **kwargs):
+        super(ConvertError, self).__init__(*args)
+        self.name = kwargs.pop("name")
+        self.raw_value = kwargs.pop("raw_value")
+        self.expected_type = kwargs.pop("expected_type")
+
+    def as_dict(self):
+        return {
+            "field": self.name,
+            "value": self.raw_value,
+            "expected_type": self.expected_type,
+        }
+
+
+class ValueRequired(ValueError):
+    def __init__(self, *args, **kwargs):
+        super(ValueRequired, self).__init__(*args)
+        self.name = kwargs.pop("name")
+
+    def as_dict(self):
+        return {
+            "field": self.name,
+            "required": True,
+        }
+
+
+class NotInited(object):
+    pass
+
+
+class BaseField(object):
+
+    type_name = "abstract_type"
+
+    def __init__(self, name, default=None, required=False):
+        self.name = name
+        self.default = default
+        self._required = required
+        self._cached_value = NotInited()
+
+    def raise_error(self, value):
+        raise ConvertError(
+            "Error: environ %s=%s is not of type %s"
+            % (self.name, self._cached_value, self.type_name),
+            name=self.name,
+            raw_value=value,
+            expected_type=self.type_name,
+        )
+
+    def _get_value(self):
+        value = os.environ.get(self.name)
+        if value is not None:
+            return self.convert(value)
+        else:
+            if self._required:
+                raise ValueRequired(
+                    "Value of environ %s is required.",
+                    name=self.name,
+                )
+        return self.default
+
+    @property
+    def value(self):
+        if isinstance(self._cached_value, NotInited):
+            self.update()
+        return self._cached_value
+
+    def update(self):
+        value = self._get_value()
+        self._cached_value = value
+        return value
+
+    def convert(self, value):
+        return value
+
+
+class StringField(BaseField):
+
+    type_name = "string"
+
+
+class IntField(BaseField):
+
+    type_name = "integer"
+
+    def convert(self, value):
+        try:
+            return int(value)
+        except ValueError:
+            self.raise_error(value)
+
+
+class FloatField(BaseField):
+
+    type_name = "float"
+
+    def convert(self, value):
+        try:
+            return float(value)
+        except ValueError:
+            self.raise_error(value)
+
+
+class BooleanField(BaseField):
+
+    type_name = "boolean"
+
+    _true_set = {"true"}
+    _false_set = {"false"}
+
+    def convert(self, value):
+        _value = value.lower()
+        if _value in self._true_set:
+            return True
+        elif _value in self._false_set:
+            return False
+        else:
+            self.raise_error(value)
+
+
+class EnvModel(object):
+
+    def __init__(self):
+        self._fields = [
+            field_name for field_name in dir(self.__class__)
+            if isinstance(getattr(self.__class__, field_name), BaseField)
+        ]
+        self.errors = []
+        self._build_data()
+
+    def _build_data(self):
+        self.errors = []
+        for field in self._fields:
+            try:
+                getattr(self.__class__, field).update()
+            except (ConvertError, ValueRequired) as e:
+                self.errors.append(e.as_dict())
+
+    def is_valid(self):
+        return len(self.errors) <= 0
+
+    def update(self):
+        """
+        Update values from env again.
+        """
+        self._build_data()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flake8>=2.2.3
 pytest>=3.0.5
+mock
 sh>=1.09
 bumpversion
 wheel

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -19,7 +19,7 @@ def set_base_env(request):
 
     def finalizer():
         for key, value in values:
-            del os.environ[key]
+            os.unsetenv(key)
 
     request.addfinalizer(finalizer=finalizer)
 

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -48,6 +48,7 @@ class TestBaseField(object):
             value = model.value
             value = model.value
             value = model.value
+        assert value == "Hi"
         assert mocked_update.call_count == 1
 
     def test_should_raise_error_if_value_is_bad(self, set_base_env):
@@ -66,7 +67,7 @@ class TestBaseField(object):
         model = NewField(field_name)
 
         with pytest.raises(orm.ConvertError) as exception:
-            value = model.value
+            model.value
         assert exception.value.name == field_name
         assert exception.value.raw_value == "Result"
         assert exception.value.expected_type == "new_field"
@@ -82,7 +83,7 @@ class TestBaseField(object):
         model = NewField(field_name, required=True)
 
         with pytest.raises(orm.ValueRequired) as exception:
-            value = model.value
+            model.value
         assert exception.value.name == field_name
 
     def test_should_update_raise_error_if_value_is_bad(self, set_base_env):
@@ -112,7 +113,7 @@ class TestIntField(object):
     def test_should_non_int_raise_error(self, set_base_env):
         model = orm.IntField("STRING_EXAMPLE")
         with pytest.raises(orm.ConvertError):
-            value = model.value
+            model.value
 
     def test_should_return_int(self, set_base_env):
         model = orm.IntField("INT_EXAMPLE")
@@ -123,7 +124,7 @@ class TestFloatField(object):
     def test_should_non_int_raise_error(self, set_base_env):
         model = orm.FloatField("STRING_EXAMPLE")
         with pytest.raises(orm.ConvertError):
-            value = model.value
+            model.value
 
     def test_should_return_int(self, set_base_env):
         model = orm.FloatField("FLOAT_EXAMPLE")
@@ -134,7 +135,7 @@ class TestBooleanField(object):
     def test_should_non_int_raise_error(self, set_base_env):
         model = orm.BooleanField("STRING_EXAMPLE")
         with pytest.raises(orm.ConvertError):
-            value = model.value
+            model.value
 
     def test_should_return_int(self, set_base_env):
         model = orm.BooleanField("BOOLEAN_EXAMPLE")

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -19,6 +19,8 @@ def set_base_env(request):
 
     def finalizer():
         for key, value in values:
+            if key in os.environ:
+                del os.environ[key]
             os.unsetenv(key)
 
     request.addfinalizer(finalizer=finalizer)

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -150,7 +150,7 @@ class TestEnvModel(object):
 
         class Model(orm.EnvModel):
             example = orm.StringField(
-                 "STRING_EXAMPLE",
+                "STRING_EXAMPLE",
             )
 
         settings = Model()

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -1,0 +1,183 @@
+import mock
+import os
+import pytest
+
+from dotenv import orm
+
+
+@pytest.fixture
+def set_base_env(request):
+
+    values = (
+        ("STRING_EXAMPLE", "Result"),
+        ("INT_EXAMPLE", "1"),
+        ("FLOAT_EXAMPLE", "1.1"),
+        ("BOOLEAN_EXAMPLE", "true"),
+    )
+    for key, value in values:
+        os.environ[key] = value
+
+    def finalizer():
+        for key, value in values:
+            del os.environ[key]
+
+    request.addfinalizer(finalizer=finalizer)
+
+
+class TestBaseField(object):
+
+    def test_should_get_string_value(self, set_base_env):
+        model = orm.BaseField("STRING_EXAMPLE")
+        assert model.value == "Result"
+
+    def test_should_got_none_if_not_set(self, set_base_env):
+        model = orm.BaseField("ENV_DOES_NOT_EXIST_")
+        assert model.value is None
+
+    def test_should_default_value_works(self, set_base_env):
+        model = orm.BaseField("ENV_DOES_NOT_EXIST_", "Hi")
+        assert model.value == "Hi"
+
+    def test_should_value_cache_works(self, set_base_env):
+        field_name = "STRING_EXAMPLE"
+
+        model = orm.BaseField(field_name)
+
+        with mock.patch.object(model, "_get_value") as mocked_update:
+            mocked_update.return_value = "Hi"
+            value = model.value
+            value = model.value
+            value = model.value
+        assert mocked_update.call_count == 1
+
+    def test_should_raise_error_if_value_is_bad(self, set_base_env):
+
+        class NewField(orm.BaseField):
+
+            type_name = "new_field"
+
+            def convert(self, value):
+                if value == "Result":
+                    self.raise_error(value)
+                return value
+
+        field_name = "STRING_EXAMPLE"
+
+        model = NewField(field_name)
+
+        with pytest.raises(orm.ConvertError) as exception:
+            value = model.value
+        assert exception.value.name == field_name
+        assert exception.value.raw_value == "Result"
+        assert exception.value.expected_type == "new_field"
+
+    def test_should_raise_error_if_value_is_required(self, set_base_env):
+
+        class NewField(orm.BaseField):
+
+            type_name = "new_field"
+
+        field_name = "ENV_DOES_NOT_EXIST"
+
+        model = NewField(field_name, required=True)
+
+        with pytest.raises(orm.ValueRequired) as exception:
+            value = model.value
+        assert exception.value.name == field_name
+
+    def test_should_update_raise_error_if_value_is_bad(self, set_base_env):
+        class NewField(orm.BaseField):
+            type_name = "new_field"
+
+            def convert(self, value):
+                self.raise_error(value)
+
+        field_name = "STRING_EXAMPLE"
+
+        model = NewField(field_name)
+
+        with pytest.raises(orm.ConvertError) as exception:
+            model.update()
+        assert exception.value.name == field_name
+        assert exception.value.raw_value == "Result"
+        assert exception.value.expected_type == "new_field"
+
+
+def test_should_string_field_works(set_base_env):
+    model = orm.StringField("STRING_EXAMPLE")
+    assert model.value == "Result"
+
+
+class TestIntField(object):
+    def test_should_non_int_raise_error(self, set_base_env):
+        model = orm.IntField("STRING_EXAMPLE")
+        with pytest.raises(orm.ConvertError):
+            value = model.value
+
+    def test_should_return_int(self, set_base_env):
+        model = orm.IntField("INT_EXAMPLE")
+        assert isinstance(model.value, int)
+
+
+class TestFloatField(object):
+    def test_should_non_int_raise_error(self, set_base_env):
+        model = orm.FloatField("STRING_EXAMPLE")
+        with pytest.raises(orm.ConvertError):
+            value = model.value
+
+    def test_should_return_int(self, set_base_env):
+        model = orm.FloatField("FLOAT_EXAMPLE")
+        assert isinstance(model.value, float)
+
+
+class TestBooleanField(object):
+    def test_should_non_int_raise_error(self, set_base_env):
+        model = orm.BooleanField("STRING_EXAMPLE")
+        with pytest.raises(orm.ConvertError):
+            value = model.value
+
+    def test_should_return_int(self, set_base_env):
+        model = orm.BooleanField("BOOLEAN_EXAMPLE")
+        assert isinstance(model.value, bool)
+
+
+class TestEnvModel(object):
+
+    def test_should_env_base_get_fields_correctly(self):
+
+        class Model(orm.EnvModel):
+            example = orm.StringField(
+                 "STRING_EXAMPLE",
+            )
+
+        settings = Model()
+
+        assert settings._fields == ["example"]
+
+    @pytest.mark.parametrize(
+        "required, is_valid",
+        (
+            (True, False),
+            (False, True),
+        )
+    )
+    def test_should_not_valid_if_value_not_given(self, required, is_valid):
+        class Model(orm.EnvModel):
+            example = orm.StringField(
+                "STRING_EXAMPLE",
+                required=required,
+            )
+
+        settings = Model()
+
+        assert settings.is_valid() is is_valid
+
+    def test_should_type_error_cause_invalid_of_model(self, set_base_env):
+
+        class Model(orm.EnvModel):
+            example = orm.IntField(
+                "STRING_EXAMPLE",
+            )
+        settings = Model()
+
+        assert settings.is_valid() is False


### PR DESCRIPTION
Hi, thanks for your awesome project for us.

I've add a orm-like setting-parser for better experience while using environment-variables as config.

Now we can use it as following example:

```
# We assume INT_EXAMPLE=1, STRING_EXAMPLE=HI
from dotenv import orm

class Model(orm.EnvModel):
    example = orm.IntField(
        "INT_EXAMPLE",
        required=False,
        default=None,
    )

settings = Model()

print(type(settings.example.value))     # int
print(settings.example.name)        # INT_EXAMPLE
print(settings.is_valid())          # True

# update (if new env is set)
settings.update()

# visit errors
print(settings.errors)
```

Would you help me to review my code and accept the pull request?