### PR TITLE
Open dotenv_path with UTF-8 encoding

### DIFF
--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -145,7 +145,7 @@ def flatten_and_write(dotenv_path, dotenv_as_dict, quote_mode="always"):
             _mode = quote_mode
             if _mode == "auto" and " " in v:
                 _mode = "always"
-            str_format = '%s="%s"\n' if _mode == "always" else '%s=%s\n'
+            str_format = u'%s="%s"\n' if _mode == "always" else u'%s=%s\n'
             f.write(str_format % (k, v))
     return True
 

--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -7,6 +7,7 @@ import sys
 import warnings
 import re
 from collections import OrderedDict
+from io import open
 
 __escape_decoder = codecs.getdecoder('unicode_escape')
 __posix_variable = re.compile('\$\{[^\}]*\}')

--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -96,7 +96,7 @@ def dotenv_values(dotenv_path):
 
 
 def parse_dotenv(dotenv_path):
-    with open(dotenv_path) as f:
+    with open(dotenv_path, encoding='utf-8') as f:
         for line in f:
             line = line.strip()
             if not line or line.startswith('#') or '=' not in line:
@@ -139,7 +139,7 @@ def resolve_nested_variables(values):
 
 
 def flatten_and_write(dotenv_path, dotenv_as_dict, quote_mode="always"):
-    with open(dotenv_path, "w") as f:
+    with open(dotenv_path, "w", encoding='utf-8') as f:
         for k, v in dotenv_as_dict.items():
             _mode = quote_mode
             if _mode == "auto" and " " in v:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 flake8>=2.2.3
-pytest>=3.0.5
+pytest>=3.2
 sh>=1.09
 bumpversion
 wheel

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
+from io import open
 
-# https://github.com/theskumar/python-dotenv/issues/45#issuecomment-277135416
-try:
-    with open('README.rst') as readme_file:
-        readme = readme_file.read()
-except:
-    readme = 'Checkout http://github.com/theskumar/python-dotenv for more details.'
+with open('README.rst', encoding='utf-8') as readme_file:
+    readme = readme_file.read()
 
 setup(
     name="python-dotenv",


### PR DESCRIPTION
This resolves #74.
I think it is better to specify the encoding when opening the .env file.