### PR TITLE
Adds dump-env to the related projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ production using `12-factor <http://12factor.net/>`__ principles.
 -  `Command-line interface <#command-line-interface>`__
 -  `iPython Support <#ipython-support>`__
 -  `Setting config on remote servers <#setting-config-on-remote-servers>`__
--  `Related Projects <#releated-projects>`__
+-  `Related Projects <#related-projects>`__
 -  `Contributing <#contributing>`__
 -  `Changelog <#changelog>`__
 
@@ -241,6 +241,7 @@ Related Projects
 -  `django-dotenv <https://github.com/jpadilla/django-dotenv>`__
 -  `django-environ <https://github.com/joke2k/django-environ>`__
 -  `django-configuration <https://github.com/jezdez/django-configurations>`__
+-  `dump-env <https://github.com/sobolevn/dump-env>`__
 
 Contributing
 ============


### PR DESCRIPTION
## Changes

Also fixes typo in "Related" projects link

## About dump-env

`dump-env` takes an `.env.template` file and some optional environmental variables to create a new `.env` file from these two sources.

### Why?


Why do we need such a tool? Well, this tool is very helpful when your CI is building ``docker`` (or other) images.
[Previously](https://github.com/wemake-services/wemake-django-template/blob/6a7ab060e8435fd855cd806706c5d1b5a9e76d12/%7B%7Bcookiecutter.project_name%7D%7D/.gitlab-ci.yml#L25) we had some complex logic of encrypting and decrypting files, importing secret keys and so on.
Now we can just create secret variables for our CI, add some prefix to it, and use `dump-env` to make our life easier.