### PR TITLE
Import IPython lazily

### DIFF
--- a/dotenv/__init__.py
+++ b/dotenv/__init__.py
@@ -1,8 +1,10 @@
 from .cli import get_cli_string
 from .main import load_dotenv, get_key, set_key, unset_key, find_dotenv
-try:
-    from .ipython import load_ipython_extension
-except ImportError:
-    pass
+
 
 __all__ = ['get_cli_string', 'load_dotenv', 'get_key', 'set_key', 'unset_key', 'find_dotenv', 'load_ipython_extension']
+
+
+def load_ipython_extension(ipython):
+    from .ipython import load_ipython_extension
+    load_ipython_extension(ipython)


### PR DESCRIPTION
`import dotenv` takes long time when IPython is installed.
This affects pypa/pipenv now.  ([ref](https://paste.ubuntu.com/26409167/))

This pull request imports `dotenv.ipython` lazily to avoid overhead.