### PR TITLE
fixes #82 by improving doc for mutiline variable example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,7 @@ ignored.
     SOME_VAR=someval
     # I am a comment and that is OK
     FOO="BAR"
+    MULTILINE_VAR="hello\nworld"
 
 ``.env`` can interpolate variables using POSIX variable expansion, variables
 are replaced from the environment first or from other values in the ``.env``


### PR DESCRIPTION
As mentioned in #82, the `\n` is required for proper parsing of multiline values. This example must be covered in the readme, This PR does just that..