### PR TITLE
Adding option for jinja templating on the env files. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__
 htmlcov/
 .cache/
 .idea
+.pytest_cache
+.venv

--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -8,12 +8,21 @@ import warnings
 import re
 from collections import OrderedDict
 
+from jinja2 import Template
+
 __escape_decoder = codecs.getdecoder('unicode_escape')
 __posix_variable = re.compile('\$\{[^\}]*\}')
 
 
 def decode_escaped(escaped):
     return __escape_decoder(escaped)[0]
+
+
+def jinja_templating(variable):
+    if "{{" in variable:
+        template = Template(variable)
+        return template.render(**os.environ)
+    return variable
 
 
 def load_dotenv(dotenv_path, verbose=False, override=False):
@@ -25,6 +34,7 @@ def load_dotenv(dotenv_path, verbose=False, override=False):
             warnings.warn("Not loading %s - it doesn't exist." % dotenv_path)
         return None
     for k, v in dotenv_values(dotenv_path).items():
+        v = jinja_templating(v)
         if override:
             os.environ[k] = v
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ wheel
 pytest-cov
 click
 ipython
+Jinja2==2.7

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     packages=['dotenv'],
     install_requires=[
         'click>=5.0',
+        'Jinja2==2.7',
     ],
     entry_points='''
         [console_scripts]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -87,6 +87,36 @@ def test_load_dotenv_override(cli):
         sh.rm(dotenv_path)
 
 
+def test_load_dotenv_variable_jinja_formatting(cli):
+    dotenv_path = '.test_load_dotenv_variable_formatting'
+
+    with cli.isolated_filesystem():
+        sh.touch(dotenv_path)
+        set_key(dotenv_path, 'a', 'foo')
+        set_key(dotenv_path, 'b', '{{a}}/bar')
+        set_key(dotenv_path, 'c', '{bar}')
+        success = load_dotenv(dotenv_path)
+        assert success
+        assert os.environ['a'] == 'foo'
+        assert os.environ['b'] == 'foo/bar'
+        assert os.environ['c'] == '{bar}'
+        sh.rm(dotenv_path)
+
+
+def test_load_dotenv_variable_filtering(cli):
+    dotenv_path = '.test_load_dotenv_variable_formatting'
+    with cli.isolated_filesystem():
+        sh.touch(dotenv_path)
+        set_key(dotenv_path, 'd', 'foo')
+        set_key(dotenv_path, 'e', '{{a|upper}}')
+        success = load_dotenv(dotenv_path)
+        assert success
+        assert os.environ['d'] == 'foo'
+        assert os.environ['e'] == os.environ['a'].upper()
+        sh.rm(dotenv_path)
+
+
+
 def test_ipython():
     tmpdir = os.path.realpath(tempfile.mkdtemp())
     os.chdir(tmpdir)


### PR DESCRIPTION
To support the following syntax 

a=foo
b={{foo}}/bar

