### PR TITLE
Allow `load_dotenv` and `dotenv_values` to work with StringIO objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 htmlcov/
 .cache/
 .idea
+.pytest_cache/

--- a/README.rst
+++ b/README.rst
@@ -115,27 +115,24 @@ top of ``wsgi.py`` and ``manage.py``.
 In-memory filelikes
 -------------------
 
-Is possible to not rely on the filesystem to parse filelikes from other sources
-(e.g. from a network storage). ``parse_dotenv`` accepts a filelike `stream`.
+It is possible to not rely on the filesystem to parse filelikes from other sources
+(e.g. from a network storage). ``load_dotenv`` and ``dotenv_values`` accepts a filelike ``stream``.
 Just be sure to rewind it before passing.
 
 .. code:: python
 
-    from io import StringIO     # Python2: from StringIO import StringIO
-    from dotenv.main import parse_dotenv
-    filelike = StringIO('SPAM=EGSS\n')
-    filelike.seek(0)
-    parsed = parse_dotenv(stream=filelike)
+    >>> from io import StringIO     # Python2: from StringIO import StringIO
+    >>> from dotenv import dotenv_values
+    >>> filelike = StringIO('SPAM=EGSS\n')
+    >>> filelike.seek(0)
+    >>> parsed = dotenv_values(stream=filelike)
+    >>> parsed['SPAM']
+    'EGSS'
 
-The returned lazy generator yields ``(key,value)`` tuples.
-To ease the consumption, is suggested to unpack it into a dictionary.
 
-.. code:: python
+The returned value is dictionary with key value pair.
 
-    os_env_like = dict(iter(parsed))
-    assert os_env_like['SPAM'] == 'EGGS'
-
-This could be useful if you need to *consume* the envfile but not *apply*  it
+``dotenv_values`` could be useful if you need to *consume* the envfile but not *apply*  it
 directly into the system environment.
 
 
@@ -292,6 +289,11 @@ Executing the tests:
 Changelog
 =========
 
+0.8.0
+----------------------------
+- Internal refractoring (`@theskumar`_)
+- Allow ``load_dotenv`` and ``dotenv_values`` to work with ``StringIO())`` (`@alanjds`_)(`@theskumar`_) (`#78`_)
+
 0.7.1
 ----------------------------
 
@@ -340,6 +342,7 @@ Changelog
 - cli: Added ``-q/--quote`` option to control the behaviour of quotes around values in ``.env``. (Thanks `@hugochinchilla`_).
 - Improved test coverage.
 
+.. _@alanjds: https://github.com/alanjds
 .. _@milonimrod: https://github.com/milonimrod
 .. _@maxkoryukov: https://github.com/maxkoryukov
 .. _@pjona: https://github.com/pjona
@@ -352,6 +355,7 @@ Changelog
 .. _@paulochf: https://github.com/paulochf
 .. _@theskumar: https://github.com/theskumar
 
+.. _#78: https://github.com/theskumar/python-dotenv/issues/78
 .. _#63: https://github.com/theskumar/python-dotenv/issues/63
 .. _#60: https://github.com/theskumar/python-dotenv/issues/60
 .. _#57: https://github.com/theskumar/python-dotenv/issues/57

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,38 @@ production using `12-factor <http://12factor.net/>`__ principles.
 
 Usages
 ======
+The easiest and most common usage consists on calling ``load_dotenv`` when the
+application starts, which will load environment variables from a file named
+``.env`` in the current directory or any of its parents or from the path specificied;
+after that, you can just call the environment-related method you need as
+provided by ``os.getenv``.
+
+``.env`` looks like this:
+
+.. code:: shell
+
+    # a comment and that will be ignored.
+    REDIS_ADDRESS=localhost:6379
+    MEANING_OF_LIFE=42
+    MULTILINE_VAR="hello\nworld"
+
+You can optionally prefix each line with the word ``export``, which will
+conveniently allow you to source the whole file on your shell.
+
+``.env`` can interpolate variables using POSIX variable expansion, variables
+are replaced from the environment first or from other values in the ``.env``
+file if the variable is not present in the environment. (``Note``: Default Value
+Expansion is not supported as of yet, see `#30 <https://github.com/theskumar/python-dotenv/pull/30#issuecomment-244036604>`__.)
+
+.. code:: shell
+
+    CONFIG_PATH=${HOME}/.config/foo
+    DOMAIN=example.org
+    EMAIL=admin@${DOMAIN}
+
+
+Getting started
+================
 
 Assuming you have created the ``.env`` file along-side your settings
 module.
@@ -43,14 +75,30 @@ Add the following code to your ``settings.py``
 .. code:: python
 
     # settings.py
-    from os.path import join, dirname
     from dotenv import load_dotenv
-
-    dotenv_path = join(dirname(__file__), '.env')
-    load_dotenv(dotenv_path)
+    load_dotenv()
 
     # OR, the same with increased verbosity:
-    load_dotenv(dotenv_path, verbose=True)
+    load_dotenv(verbose=True)
+
+    # OR, explicitly providing path to '.env'
+    from pathlib import Path  # python3 only
+    env_path = Path('.') / '.env'
+    load_dotenv(dotenv_path=env_path)
+
+
+Now, you can access the variables either from system environment
+variable or loaded from ``.env`` file.
+
+.. code:: python
+
+    # settings.py
+    import os
+    SECRET_KEY = os.getenv("EMAIL")
+    DATABASE_PASSWORD = os.getenv("DATABASE_PASSWORD")
+
+ **System environment variables gets higher precedence**, but you can override existing
+ system environment vars by using ``load_dotenv(override=True)``.
 
 Alternatively, you can use ``find_dotenv()`` method that will try to find a
 ``.env`` file by (a) guessing where to start using ``__file__`` or the working
@@ -62,54 +110,6 @@ specified file -- called ``.env`` by default.
 
     from dotenv import load_dotenv, find_dotenv
     load_dotenv(find_dotenv())
-
-You can also set ``load_dotenv`` to override existing variables:
-
-.. code:: python
-
-    from dotenv import load_dotenv, find_dotenv
-    load_dotenv(find_dotenv(), override=True)
-
-Now, you can access the variables either from system environment
-variable or loaded from ``.env`` file. **System environment variables
-gets higher precedence** and it's advised not to include it in version control.
-
-.. code:: python
-
-    # settings.py
-
-    SECRET_KEY = os.environ.get("SECRET_KEY")
-    DATABASE_PASSWORD = os.environ.get("DATABASE_PASSWORD")
-
-
-``.env`` is a simple text file. With each environment variables listed
-per line, in the format of ``KEY="Value"``, lines starting with `#` is
-ignored.
-
-.. code:: shell
-
-    SOME_VAR=someval
-    # I am a comment and that is OK
-    FOO="BAR"
-    MULTILINE_VAR="hello\nworld"
-
-``.env`` can interpolate variables using POSIX variable expansion, variables
-are replaced from the environment first or from other values in the ``.env``
-file if the variable is not present in the environment. (``Note``: Default Value
-Expansion is not supported as of yet, see `#30 <https://github.com/theskumar/python-dotenv/pull/30#issuecomment-244036604>`__.)
-
-.. code:: shell
-
-    CONFIG_PATH=${HOME}/.config/foo
-    DOMAIN=example.org
-    EMAIL=admin@${DOMAIN}
-
-
-Django
-------
-
-If you are using django you should add the above loader script at the
-top of ``wsgi.py`` and ``manage.py``.
 
 
 In-memory filelikes
@@ -136,6 +136,13 @@ The returned value is dictionary with key value pair.
 directly into the system environment.
 
 
+Django
+------
+
+If you are using django you should add the above loader script at the
+top of ``wsgi.py`` and ``manage.py``.
+
+
 Installation
 ============
 
@@ -143,8 +150,32 @@ Installation
 
     pip install -U python-dotenv
 
+
+iPython Support
+---------------
+
+You can use dotenv with iPython. You can either let the dotenv search for .env with `%dotenv` or provide the path to .env file explicitly, see below for usages.
+
+::
+
+    %load_ext dotenv
+
+    # Use find_dotenv to locate the file
+    %dotenv
+
+    # Specify a particular file
+    %dotenv relative/or/absolute/path/to/.env
+
+    # Use _-o_ to indicate override of existing variables
+    %dotenv -o
+
+    # Use _-v_ to turn verbose mode on
+    %dotenv -v
+
+
+
 Command-line interface
-======================
+=================
 
 A cli interface ``dotenv`` is also included, which helps you manipulate
 the ``.env`` file without manually opening it. The same cli installed on
@@ -171,27 +202,6 @@ update your settings on remote server, handy isn't it!
       list   Display all the stored key/value.
       set    Store the given key/value.
       unset  Removes the given key.
-
-iPython Support
----------------
-
-You can use dotenv with iPython. You can either let the dotenv search for .env with `%dotenv` or provide the path to .env file explicitly, see below for usages.
-
-::
-
-    %load_ext dotenv
-
-    # Use find_dotenv to locate the file
-    %dotenv
-
-    # Specify a particular file
-    %dotenv relative/or/absolute/path/to/.env
-
-    # Use _-o_ to indicate override of existing variables
-    %dotenv -o
-
-    # Use _-v_ to turn verbose mode on
-    %dotenv -v
 
 
 Setting config on remote servers
@@ -232,6 +242,7 @@ Get all your remote config info with ``fab config``
 ::
 
     $ fab config
+    foo="bar"
 
 Set remote config variables with ``fab config:set,<key>,<value>``
 
@@ -291,6 +302,8 @@ Changelog
 
 0.8.0
 ----------------------------
+- ``set_key`` and ``unset_key`` only modified the affected file instead of parsing and re-writing file, this causes comments and other file entact as it is.
+- Add support for ``export `` prefix in the line.
 - Internal refractoring (`@theskumar`_)
 - Allow ``load_dotenv`` and ``dotenv_values`` to work with ``StringIO())`` (`@alanjds`_)(`@theskumar`_) (`#78`_)
 

--- a/README.rst
+++ b/README.rst
@@ -87,8 +87,8 @@ Add the following code to your ``settings.py``
     load_dotenv(dotenv_path=env_path)
 
 
-Now, you can access the variables either from system environment
-variable or loaded from ``.env`` file.
+At this point, parsed key/value from the `.env` file is now present as system
+environment variable and they can be conveniently accessed via ``os.getenv()``
 
 .. code:: python
 
@@ -97,14 +97,13 @@ variable or loaded from ``.env`` file.
     SECRET_KEY = os.getenv("EMAIL")
     DATABASE_PASSWORD = os.getenv("DATABASE_PASSWORD")
 
- **System environment variables gets higher precedence**, but you can override existing
- system environment vars by using ``load_dotenv(override=True)``.
 
-Alternatively, you can use ``find_dotenv()`` method that will try to find a
-``.env`` file by (a) guessing where to start using ``__file__`` or the working
-directory -- allowing this to work in non-file contexts such as IPython notebooks
-and the REPL, and then (b) walking up the directory tree looking for the
-specified file -- called ``.env`` by default.
+ ``load_dotenv`` do not override existing System environment variables, but
+ you can do so if you want by passing ``override=True`` to ``load_dotenv()``.
+
+You can use ``find_dotenv()`` method that will try to find a ``.env`` file by
+(a) guessing where to start using ``__file__`` or the working directory -- allowing this to work in non-file contexts such as IPython notebooks and the REPL, and then
+(b) walking up the directory tree looking for the specified file -- called ``.env`` by default.
 
 .. code:: python
 

--- a/dotenv/__init__.py
+++ b/dotenv/__init__.py
@@ -1,8 +1,15 @@
 from .cli import get_cli_string
-from .main import load_dotenv, get_key, set_key, unset_key, find_dotenv
+from .main import load_dotenv, get_key, set_key, unset_key, find_dotenv, dotenv_values
 
 
-__all__ = ['get_cli_string', 'load_dotenv', 'get_key', 'set_key', 'unset_key', 'find_dotenv', 'load_ipython_extension']
+__all__ = ['get_cli_string',
+           'load_dotenv',
+           'dotenv_values',
+           'get_key',
+           'set_key',
+           'unset_key',
+           'find_dotenv',
+           'load_ipython_extension']
 
 
 def load_ipython_extension(ipython):

--- a/dotenv/cli.py
+++ b/dotenv/cli.py
@@ -2,7 +2,7 @@ import os
 
 import click
 
-from .main import get_key, dotenv_values, set_key, unset_key
+from .main import dotenv_values, get_key, set_key, unset_key
 
 
 @click.group()

--- a/dotenv/compat.py
+++ b/dotenv/compat.py
@@ -1,0 +1,4 @@
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO

--- a/dotenv/compat.py
+++ b/dotenv/compat.py
@@ -1,4 +1,4 @@
 try:
-    from StringIO import StringIO
+    from StringIO import StringIO  # noqa
 except ImportError:
-    from io import StringIO
+    from io import StringIO  # noqa

--- a/dotenv/ipython.py
+++ b/dotenv/ipython.py
@@ -1,9 +1,10 @@
 from __future__ import print_function
-from .main import load_dotenv, find_dotenv
 
-from IPython.core.magic import Magics, magics_class, line_magic
+from IPython.core.magic import Magics, line_magic, magics_class
 from IPython.core.magic_arguments import (argument, magic_arguments,
                                           parse_argstring)
+
+from .main import find_dotenv, load_dotenv
 
 
 @magics_class

--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -246,10 +246,10 @@ def find_dotenv(filename='.env', raise_error_if_not_found=False, usecwd=False):
 
 
 def load_dotenv(dotenv_path=None, stream=None, verbose=False, override=False):
-    f = stream or dotenv_path
+    f = dotenv_path or stream or find_dotenv()
     return DotEnv(f, verbose=verbose).set_as_environment_variables(override=override)
 
 
 def dotenv_values(dotenv_path=None, stream=None, verbose=False):
-    f = stream or dotenv_path
+    f = dotenv_path or stream or find_dotenv()
     return DotEnv(f, verbose=verbose).dict()

--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -21,19 +21,31 @@ def decode_escaped(escaped):
 
 def parse_line(line):
     line = line.strip()
+
+    # Ignore lines with `#` or which doesn't have `=` in it.
     if not line or line.startswith('#') or '=' not in line:
         return None, None
 
     k, v = line.split('=', 1)
 
-    # Remove any leading and trailing spaces in key, value
-    k, v = k.strip(), v.strip().encode('unicode-escape').decode('ascii')
+    if k.startswith('export '):
+        k = k.lstrip('export ')
 
-    if len(v) > 0:
+    # Remove any leading and trailing spaces in key, value
+    k, v = k.strip(), v.strip()
+
+    if v:
+        v = v.encode('unicode-escape')
+        try:
+            v = v.decode('ascii')
+        except UnicodeDecodeError:
+            pass
+
         quoted = v[0] == v[-1] in ['"', "'"]
 
         if quoted:
             v = decode_escaped(v[1:-1])
+
     return k, v
 
 

--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -45,17 +45,18 @@ class DotEnv():
         self.verbose = verbose
 
     def _get_stream(self):
+        self._is_file = False
         if isinstance(self.dotenv_path, StringIO):
-            self._is_file = False
             return self.dotenv_path
 
-        if not os.path.exists(self.dotenv_path):
-            if self.verbose:
-                warnings.warn("File doesn't exist {}".format(self.dotenv_path))
-            return None
+        if os.path.exists(self.dotenv_path):
+            self._is_file = True
+            return open(self.dotenv_path)
 
-        self._is_file = True
-        return open(self.dotenv_path)
+        if self.verbose:
+            warnings.warn("File doesn't exist {}".format(self.dotenv_path))
+
+        return StringIO('')
 
     def dict(self):
         """Return dotenv as dict"""
@@ -68,8 +69,6 @@ class DotEnv():
 
     def parse(self):
         f = self._get_stream()
-        if not f:
-            return None
 
         for line in f:
             key, value = parse_line(line)

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,5 @@ exclude = .tox,.git,docs,venv,.venv
 description-file = README.rst
 
 [tool:pytest]
-norecursedirs = .svn _build tmp* dist venv .git .venv
+norecursedirs = .svn _build tmp* dist venv .git .venv venv
 flake8-max-line-length = 120

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,12 +6,9 @@ import pytest
 import tempfile
 import warnings
 import sh
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 from dotenv import load_dotenv, find_dotenv, set_key, dotenv_values
+from dotenv.compat import StringIO
 from IPython.terminal.embed import InteractiveShellEmbed
 
 
@@ -118,9 +115,17 @@ def test_ipython_override():
     assert os.environ["MYNEWVALUE"] == 'q1w2e3'
 
 
-def test_parse_dotenv_stream():
+def test_dotenv_values_stream():
     stream = StringIO(u'hello="it works!😃"\nDOTENV=${hello}\n')
     stream.seek(0)
     parsed_dict = dotenv_values(stream=stream)
     assert 'DOTENV' in parsed_dict
     assert parsed_dict['DOTENV'] == u'it works!😃'
+
+
+def test_dotenv_values_export():
+    stream = StringIO('export foo=bar\n')
+    stream.seek(0)
+    load_dotenv(stream=stream)
+    assert 'foo' in os.environ
+    assert os.environ['foo'] == 'bar'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,8 +9,7 @@ try:
 except ImportError:
     from io import StringIO
 
-from dotenv import load_dotenv, find_dotenv, set_key
-from dotenv.main import parse_dotenv
+from dotenv import load_dotenv, find_dotenv, set_key, dotenv_values
 from IPython.terminal.embed import InteractiveShellEmbed
 
 
@@ -20,7 +19,7 @@ def test_warns_if_file_does_not_exist():
 
         assert len(w) == 1
         assert w[0].category is UserWarning
-        assert str(w[0].message) == "Not loading .does_not_exist - it doesn't exist."
+        assert str(w[0].message) == "File doesn't exist .does_not_exist"
 
 
 def test_find_dotenv():
@@ -118,9 +117,8 @@ def test_ipython_override():
 
 
 def test_parse_dotenv_stream():
-    stream = StringIO('DOTENV=WORKS\n')
+    stream = StringIO('hello="it works!😃"\nDOTENV=${hello}\n')
     stream.seek(0)
-    parsed_generator = parse_dotenv(stream=stream)
-    parsed_dict = dict(iter(parsed_generator))
+    parsed_dict = dotenv_values(stream=stream)
     assert 'DOTENV' in parsed_dict
-    assert parsed_dict['DOTENV'] == 'WORKS'
+    assert parsed_dict['DOTENV'] == 'it works!😃'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,6 @@
 # -*- coding: utf8 -*-
+from __future__ import unicode_literals
+
 import os
 import pytest
 import tempfile
@@ -117,8 +119,8 @@ def test_ipython_override():
 
 
 def test_parse_dotenv_stream():
-    stream = StringIO('hello="it works!😃"\nDOTENV=${hello}\n')
+    stream = StringIO(u'hello="it works!😃"\nDOTENV=${hello}\n')
     stream.seek(0)
     parsed_dict = dotenv_values(stream=stream)
     assert 'DOTENV' in parsed_dict
-    assert parsed_dict['DOTENV'] == 'it works!😃'
+    assert parsed_dict['DOTENV'] == u'it works!😃'


### PR DESCRIPTION
supersede #78 