### PR TITLE
Fix RST errors in README.rst and test for errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,16 @@ python:
   - '3.6'
   - pypy
 install:
-  - pip install python-coveralls
+  - pip install python-coveralls docutils
   - pip install -q -r requirements.txt
   - pip install --editable .
 script:
   - flake8 .
   - pytest -v --tb=native --cov
+  - |
+    if python -c 'import sys; sys.exit(0 if sys.version_info >= (3, 4) else 1)' ; then
+      python setup.py check --metadata --restructuredtext --strict
+    fi
 after_success:
   - coveralls
 deploy:

--- a/README.rst
+++ b/README.rst
@@ -172,7 +172,7 @@ You can use dotenv with iPython. You can either let the dotenv search for .env w
 
 
 Command-line interface
-=================
+======================
 
 For commandline support, use the `cli` option during installation:
 
@@ -307,7 +307,7 @@ Changelog
 0.8.0
 ----------------------------
 - ``set_key`` and ``unset_key`` only modified the affected file instead of parsing and re-writing file, this causes comments and other file entact as it is.
-- Add support for ``export `` prefix in the line.
+- Add support for ``export`` prefix in the line.
 - Internal refractoring (`@theskumar`_)
 - Allow ``load_dotenv`` and ``dotenv_values`` to work with ``StringIO())`` (`@alanjds`_)(`@theskumar`_) (`#78`_)
 


### PR DESCRIPTION
Having valid RST is important so that Pypi's web interface interprets the RST correctly and display `long_description` in a pretty format. Right now, the Pypi page looks pretty ugly:

https://pypi.python.org/pypi/python-dotenv

This pull request fixes the errors, and also adds a simple test to avoid this problem in the future.