### PR TITLE
Force environment variables to str with Python2 on Windows

### DIFF
--- a/dotenv/compat.py
+++ b/dotenv/compat.py
@@ -1,4 +1,9 @@
+import sys
 try:
     from StringIO import StringIO  # noqa
 except ImportError:
     from io import StringIO  # noqa
+
+PY2 = sys.version_info[0] == 2
+WIN = sys.platform.startswith('win')
+text_type = unicode if PY2 else str  # noqa

--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -18,6 +18,7 @@ __posix_variable = re.compile('\$\{[^\}]*\}')
 PY2 = sys.version_info[0] == 2
 WIN = sys.platform.startswith('win')
 
+
 def decode_escaped(escaped):
     return __escape_decoder(escaped)[0]
 

--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -15,6 +15,8 @@ from .compat import StringIO
 __escape_decoder = codecs.getdecoder('unicode_escape')
 __posix_variable = re.compile('\$\{[^\}]*\}')
 
+PY2 = sys.version_info[0] == 2
+WIN = sys.platform.startswith('win')
 
 def decode_escaped(escaped):
     return __escape_decoder(escaped)[0]
@@ -94,6 +96,12 @@ class DotEnv():
         for k, v in self.dict().items():
             if k in os.environ and not override:
                 continue
+            # With Python2 on Windows, force environment variables to str to avoid
+            # "TypeError: environment can only contain strings" in Python's subprocess.py.
+            if PY2 and WIN:
+                if isinstance(k, unicode) or isinstance(v, unicode):
+                    k = k.encode('ascii')
+                    v = v.encode('ascii')
             os.environ[k] = v
 
         return True

--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -10,14 +10,10 @@ import sys
 import warnings
 from collections import OrderedDict
 
-from .compat import StringIO
+from .compat import StringIO, PY2, WIN, text_type
 
 __escape_decoder = codecs.getdecoder('unicode_escape')
 __posix_variable = re.compile('\$\{[^\}]*\}')
-
-PY2 = sys.version_info[0] == 2
-WIN = sys.platform.startswith('win')
-text_type = unicode if PY2 else str
 
 
 def decode_escaped(escaped):

--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -17,6 +17,7 @@ __posix_variable = re.compile('\$\{[^\}]*\}')
 
 PY2 = sys.version_info[0] == 2
 WIN = sys.platform.startswith('win')
+text_type = unicode if PY2 else str
 
 
 def decode_escaped(escaped):
@@ -100,7 +101,7 @@ class DotEnv():
             # With Python2 on Windows, force environment variables to str to avoid
             # "TypeError: environment can only contain strings" in Python's subprocess.py.
             if PY2 and WIN:
-                if isinstance(k, unicode) or isinstance(v, unicode):
+                if isinstance(k, text_type) or isinstance(v, text_type):
                     k = k.encode('ascii')
                     v = v.encode('ascii')
             os.environ[k] = v


### PR DESCRIPTION
With Python2 on Windows, force environment variables to str to avoid "TypeError: environment can only contain strings" in Python's subprocess.py.

Fix #88 