### PR TITLE
Better detection of interactive shells and project directory

### DIFF
--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -7,7 +7,6 @@ import inspect
 import io
 import os
 import re
-import sys
 import warnings
 from collections import OrderedDict
 

--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -220,14 +220,21 @@ def _walk_to_root(path):
         last_dir, current_dir = current_dir, parent_dir
 
 
+def _is_interactive():
+    """
+    Decide whether this is running in a REPL or IPython notebook
+    """
+    main = __import__('__main__', None, None, fromlist=['__file__'])
+    return not hasattr(main, '__file__')
+
+
 def find_dotenv(filename='.env', raise_error_if_not_found=False, usecwd=False):
     """
     Search in increasingly higher folders for the given file
 
     Returns path to the file if found, or an empty string otherwise
     """
-    if usecwd or '__file__' not in globals():
-        # should work without __file__, e.g. in REPL or IPython notebook
+    if usecwd or _is_interactive():
         path = os.getcwd()
     else:
         # will work for .py files

--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import codecs
 import fileinput
+import inspect
 import io
 import os
 import re
@@ -238,8 +239,11 @@ def find_dotenv(filename='.env', raise_error_if_not_found=False, usecwd=False):
         path = os.getcwd()
     else:
         # will work for .py files
-        frame_filename = sys._getframe().f_back.f_code.co_filename
-        path = os.path.dirname(os.path.abspath(frame_filename))
+        frames = inspect.getouterframes(inspect.currentframe())
+        for frame in frames:
+            if frame.filename != __file__:
+                break
+        path = os.path.dirname(os.path.abspath(frame.filename))
 
     for dirname in _walk_to_root(path):
         check_path = os.path.join(dirname, filename)


### PR DESCRIPTION
We were using python-dotenv and noticed some problems when calling `load_dotenv()`, namely, that it wasn't finding the .env file in our project directory correctly. However, calling `load_dotenv(find_dotenv())` worked just fine. This was failing in interactive shells and when running .py files.

I did a bit of investigation this morning and noticed two things that seemed off. These are noted in the commits below. dotenv project tests pass with `py.test tests/` in CPython 2.7.10 and 3.6.4.

Cheers!