### PR TITLE
Fix to enable loading from current directory

### DIFF
--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -232,7 +232,11 @@ def find_dotenv(filename='.env', raise_error_if_not_found=False, usecwd=False):
         path = os.getcwd()
     else:
         # will work for .py files
-        frame_filename = sys._getframe().f_back.f_code.co_filename
+        frame = sys._getframe()
+        # find first frame that is outside of this file
+        while frame.f_code.co_filename == __file__:
+            frame = frame.f_back
+        frame_filename = frame.f_code.co_filename
         path = os.path.dirname(os.path.abspath(frame_filename))
 
     for dirname in _walk_to_root(path):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,17 +38,6 @@ def test_warns_if_file_does_not_exist():
         assert str(w[0].message) == "File doesn't exist .does_not_exist"
 
 
-def test_load_dotenv_in_current_dir():
-    dotenv_path = '.env'
-    with open(dotenv_path, 'w') as f:
-        f.write("TOTO=bla\n")
-    assert 'TOTO' not in os.environ
-    success = load_dotenv(verbose=True)
-    assert success
-    assert os.environ['TOTO'] == 'bla'
-    sh.rm(dotenv_path)
-
-
 def test_find_dotenv():
     """
     Create a temporary folder structure like the following:
@@ -116,6 +105,19 @@ def test_load_dotenv_override(cli):
         assert key_name in os.environ
         assert os.environ[key_name] == 'WORKS'
         sh.rm(dotenv_path)
+
+
+def test_load_dotenv_in_current_dir():
+    # make sure were are here!
+    os.chdir(os.path.dirname(os.path.realpath(__file__)))
+    dotenv_path = '.env'
+    with open(dotenv_path, 'w') as f:
+        f.write("TOTO=bla\n")
+    assert 'TOTO' not in os.environ
+    success = load_dotenv(verbose=True)
+    assert success
+    assert os.environ['TOTO'] == 'bla'
+    sh.rm(dotenv_path)
 
 
 def test_ipython():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,6 +38,17 @@ def test_warns_if_file_does_not_exist():
         assert str(w[0].message) == "File doesn't exist .does_not_exist"
 
 
+def test_load_dotenv_in_current_dir():
+    dotenv_path = '.env'
+    with open(dotenv_path, 'w') as f:
+        f.write("TOTO=bla\n")
+    assert 'TOTO' not in os.environ
+    success = load_dotenv(verbose=True)
+    assert success
+    assert os.environ['TOTO'] == 'bla'
+    sh.rm(dotenv_path)
+
+
 def test_find_dotenv():
     """
     Create a temporary folder structure like the following:
@@ -105,17 +116,6 @@ def test_load_dotenv_override(cli):
         assert key_name in os.environ
         assert os.environ[key_name] == 'WORKS'
         sh.rm(dotenv_path)
-
-
-def test_load_dotenv_in_current_dir():
-    dotenv_path = '.env'
-    with open(dotenv_path, 'w') as f:
-        f.write("TOTO=bla\n")
-    assert 'TOTO' not in os.environ
-    success = load_dotenv(verbose=True)
-    assert success
-    assert os.environ['TOTO'] == 'bla'
-    sh.rm(dotenv_path)
 
 
 def test_ipython():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 import os
@@ -105,6 +105,17 @@ def test_load_dotenv_override(cli):
         assert key_name in os.environ
         assert os.environ[key_name] == 'WORKS'
         sh.rm(dotenv_path)
+
+
+def test_load_dotenv_in_current_dir():
+    dotenv_path = '.env'
+    with open(dotenv_path, 'w') as f:
+        f.write("TOTO=bla\n")
+    assert 'TOTO' not in os.environ
+    success = load_dotenv(verbose=True)
+    assert success
+    assert os.environ['TOTO'] == 'bla'
+    sh.rm(dotenv_path)
 
 
 def test_ipython():


### PR DESCRIPTION
This is a fix for #108, which is due I believe to the fact that `find_dotenv` does not go back far enough in the call stack to find the calling module, which causes its path searching starting point to be itself (i.e. `main.py`).

@theskumar, @RazerM 