### PR TITLE
Add new line when updating key with "set_key" (Alternative to PR#103)

### DIFF
--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -143,7 +143,7 @@ def set_key(dotenv_path, key_to_set, value_to_set, quote_mode="always"):
         k, v = parse_line(line)
         if k == key_to_set:
             replaced = True
-            line = line_out
+            line = "{}\n".format(line_out)
         print(line, end='')
 
     if not replaced:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,13 +24,19 @@ def test_get_key():
 
 
 def test_set_key(dotenv_file):
-    success, key_to_set, value_to_set = dotenv.set_key(dotenv_path, 'HELLO', 'WORLD')
-    success, key_to_set, value_to_set = dotenv.set_key(dotenv_path, 'foo', 'bar')
-    dotenv.get_key(dotenv_path, 'HELLO') == 'WORLD'
+    success, key_to_set, value_to_set = dotenv.set_key(dotenv_file, 'HELLO', 'WORLD')
+    success, key_to_set, value_to_set = dotenv.set_key(dotenv_file, 'foo', 'bar')
+    assert dotenv.get_key(dotenv_file, 'HELLO') == 'WORLD'
 
-    success, key_to_set, value_to_set = dotenv.set_key(dotenv_path, 'HELLO', 'WORLD 2')
-    dotenv.get_key(dotenv_path, 'HELLO') == 'WORLD 2'
-    dotenv.get_key(dotenv_path, 'foo') == 'bar'
+    with open(dotenv_file, 'r') as fp:
+        assert 'HELLO="WORLD"\nfoo="bar"\n' == fp.read()
+
+    success, key_to_set, value_to_set = dotenv.set_key(dotenv_file, 'HELLO', 'WORLD 2')
+    assert dotenv.get_key(dotenv_file, 'HELLO') == 'WORLD 2'
+    assert dotenv.get_key(dotenv_file, 'foo') == 'bar'
+
+    with open(dotenv_file, 'r') as fp:
+        assert 'HELLO="WORLD 2"\nfoo="bar"\n' == fp.read()
 
 
 def test_list(cli, dotenv_file):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,14 +29,14 @@ def test_set_key(dotenv_file):
     assert dotenv.get_key(dotenv_file, 'HELLO') == 'WORLD'
 
     with open(dotenv_file, 'r') as fp:
-        assert 'HELLO="WORLD"\nfoo="bar"\n' == fp.read()
+        assert 'HELLO="WORLD"\nfoo="bar"' == fp.read().strip()
 
     success, key_to_set, value_to_set = dotenv.set_key(dotenv_file, 'HELLO', 'WORLD 2')
     assert dotenv.get_key(dotenv_file, 'HELLO') == 'WORLD 2'
     assert dotenv.get_key(dotenv_file, 'foo') == 'bar'
 
     with open(dotenv_file, 'r') as fp:
-        assert 'HELLO="WORLD 2"\nfoo="bar"\n' == fp.read()
+        assert 'HELLO="WORLD 2"\nfoo="bar"' == fp.read().strip()
 
 
 def test_list(cli, dotenv_file):


### PR DESCRIPTION
This is an alternative to PR#103

When using "dotenv set", a new line is not put after the replaced key, causing key/values to end up on the same line.

To reproduce:

Create an env file with some keys and values int it:

`test.env`
```
key1="value1"
key2="value2"
key3="value3"
```

run:
```
dotenv -f test.env set key1 value11
```

`test.env` now looks like:
```
key1="value11"key2="value2"
key3="value3"
```

Also updated tests for `set_key` to reflect changes.