### PR TITLE
Bugfix: parse_line incorrectly strips "export " prefix

### DIFF
--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -31,7 +31,7 @@ def parse_line(line):
     k, v = line.split('=', 1)
 
     if k.startswith('export '):
-        k = k.lstrip('export ')
+        (_, _, k) = k.partition('export ')
 
     # Remove any leading and trailing spaces in key, value
     k, v = k.strip(), v.strip()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,6 +24,8 @@ from IPython.terminal.embed import InteractiveShellEmbed
     ("a=b space ", ('a', 'b space')),
     ("a='b space '", ('a', 'b space ')),
     ('a="b space "', ('a', 'b space ')),
+    ("export export_spam=1", ("export_spam", "1")),
+    ("export port=8000", ("port", "8000")),
 ])
 def test_parse_line(test_input, expected):
     assert parse_line(test_input) == expected


### PR DESCRIPTION
`parse_line` currently implements the stripping of the `"export "` prefix incorrectly, such that any variable name prefix consisting of the characters ` eoprtx` will get stripped too.

This means that for example `export port_number = 8000` will get parsed as `_number = 8000`.