### PR TITLE
EGSS → EGGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ before passing.
 ```python
 >>> from io import StringIO     # Python2: from StringIO import StringIO
 >>> from dotenv import dotenv_values
->>> filelike = StringIO('SPAM=EGSS\n')
+>>> filelike = StringIO('SPAM=EGGS\n')
 >>> filelike.seek(0)
 >>> parsed = dotenv_values(stream=filelike)
 >>> parsed['SPAM']
-'EGSS'
+'EGGS'
 ```
 
 The returned value is dictionary with key value pair.


### PR DESCRIPTION
Not sure if this was intentional or not, but I'm pretty sure that EGGS is normally spelt with two Gs and one S.