### PR TITLE
Allow multi-line ENV values

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,7 @@ bumpversion
 wheel
 pytest-cov
 click
-ipython
+ipython<6; python_version <= '2'
+ipython<7; python_version <= '3.3'
+ipython; python_version > '3.3'
 pypandoc

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ bumpversion
 wheel
 pytest-cov
 click
+jedi<0.13; python_version <= '3.3'
 ipython<6; python_version <= '2'
 ipython<7; python_version <= '3.3'
 ipython; python_version > '3.3'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import tempfile
 from os import environ
 from os.path import dirname, join
 
@@ -93,6 +94,18 @@ def test_value_with_special_characters():
         f.write(r"TEST='}=&~{,(\5%{&;'")
     assert dotenv.get_key(dotenv_path, 'TEST') == r'}=&~{,(\5%{&;'
     sh.rm(dotenv_path)
+
+
+def test_multiline_value():
+    with tempfile.NamedTemporaryFile() as f:
+        f.write("TEST='line 1\nline 2'".encode('utf-8'))
+        f.flush()
+        assert dotenv.get_key(f.name, 'TEST') == "line 1\nline 2"
+
+    with tempfile.NamedTemporaryFile() as f:
+        f.write("TEST='line 1\nline 2'\nFIZZ=BUZZ".encode('utf-8'))
+        f.flush()
+        assert dotenv.get_key(f.name, 'TEST') == "line 1\nline 2"
 
 
 def test_unset():


### PR DESCRIPTION
Use regex to parse ENV variable names from .env

Example `.env` file that is currently not parsed correctly (this is not a real private key):

```
PRIVATE_KEY='-----BEGIN RSA PRIVATE KEY-----
MIICXgIBAAKBgQCiiy07/kQ/O9bQgIbg/+RjjPEfqvalNqZPHjKW0rqL3E3fGvOe
dksb0IsHJKS80Va+jtz7pO2nuLjQ2pYm7StQO/8ya0WnmndL12kTSR+Kjbr4WHJV
ZH3pXA+E2rdubHnodD5uHMrlqPsgrmAtHTTHww0GB1hfAQb1HNx8GezauwIDAQAB
AoGABNdgYYkRP1Do9Qze95SnmM953xeYgRM/oNulZhigtcm6CAsldnLPieSMP4o3
3efeTY6zxksDSRuXZaEdF8u4nn60L2M3oAbL6JPplLgCjRNW2q9mIBQ0rChEFHrU
oBwTcEE/H8RfaAJu7baT4PQXU9jk1DxqGCPiTkNGetGqKAECQQD/yMwprtUSEKA4
SGA5HtCXfZSE6M5698okL2VcmZlzdYFh0wWGNZHgBoR/N3obv7ioqr74UboxM0Yi
psdGE1mhAkEAoq5BnP9QpDZ9eywoXLBSXqR3/WXsYIHgq0ETC5xlquma6qHVPo+B
tSkMxgg8c8fzy5tPSf/AWwwOxSD5AVxu2wJBANkLT0sTgtPobbw0lgoCPug9dJhv
YD5yIwIfgbhY0iBqFlanFKn0rQrXHPlCXwhK4GunL5NQ7livdJUUxkWNR+ECQQCH
zXn+inASNV641Rr4jUSltxxnj48s3R7lN1Sjy7JfY9Wr6t7t87Ruu87q/fMhIBkX
rhYZiwNTvhQSYb0ccsIjAkEA3qDEu1ouTHGAbLguryJ5uw10oEROYuydt55qeT05
IV/wDZ9X6+qJE+BBatO9T+fJGSzKOBCFhmdVdbOLs1t2g==
-----END RSA PRIVATE KEY-----'
PRIVATE_KEY_ID='fizzbuzz'
```