### PR TITLE
Add support for newlines, backslashes, trailing comments and unquoted UTF-8

### DIFF
--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -14,7 +14,7 @@ from collections import OrderedDict
 from .compat import StringIO, PY2, WIN, text_type
 
 __escape_decoder = codecs.getdecoder('unicode_escape')
-__posix_variable = re.compile('\$\{[^\}]*\}')  # noqa
+__posix_variable = re.compile(r'\$\{[^\}]*\}')
 
 
 def decode_escaped(escaped):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
-from os import environ
+import os
 from os.path import dirname, join
 
-import dotenv
-from dotenv.version import __version__
-from dotenv.cli import cli as dotenv_cli
-
+import pytest
 import sh
+
+import dotenv
+from dotenv.cli import cli as dotenv_cli
+from dotenv.version import __version__
 
 here = dirname(__file__)
 dotenv_path = join(here, '.env')
@@ -37,6 +38,17 @@ def test_set_key(dotenv_file):
 
     with open(dotenv_file, 'r') as fp:
         assert 'HELLO="WORLD 2"\nfoo="bar"' == fp.read().strip()
+
+
+def test_set_key_permission_error(dotenv_file):
+    os.chmod(dotenv_file, 0o000)
+
+    with pytest.raises(Exception):
+        dotenv.set_key(dotenv_file, "HELLO", "WORLD")
+
+    os.chmod(dotenv_file, 0o600)
+    with open(dotenv_file, "r") as fp:
+        assert fp.read() == ""
 
 
 def test_list(cli, dotenv_file):
@@ -95,18 +107,22 @@ def test_value_with_special_characters():
     sh.rm(dotenv_path)
 
 
-def test_unset():
-    sh.touch(dotenv_path)
-    success, key_to_set, value_to_set = dotenv.set_key(dotenv_path, 'HELLO', 'WORLD')
-    stored_value = dotenv.get_key(dotenv_path, 'HELLO')
-    assert stored_value == 'WORLD'
-    success, key_to_unset = dotenv.unset_key(dotenv_path, 'HELLO')
+def test_unset_ok(dotenv_file):
+    with open(dotenv_file, "w") as f:
+        f.write("a=b\nc=d")
+
+    success, key_to_unset = dotenv.unset_key(dotenv_file, "a")
+
     assert success is True
-    assert dotenv.get_key(dotenv_path, 'HELLO') is None
-    success, key_to_unset = dotenv.unset_key(dotenv_path, 'RANDOM')
-    assert success is None
-    sh.rm(dotenv_path)
-    success, key_to_unset = dotenv.unset_key(dotenv_path, 'HELLO')
+    assert key_to_unset == "a"
+    with open(dotenv_file, "r") as f:
+        assert f.read() == "c=d"
+    sh.rm(dotenv_file)
+
+
+def test_unset_non_existing_file():
+    success, key_to_unset = dotenv.unset_key('/non-existing', 'HELLO')
+
     assert success is None
 
 
@@ -180,7 +196,7 @@ def test_get_key_with_interpolation(cli):
         stored_value = dotenv.get_key(dotenv_path, 'BAR')
         assert stored_value == 'CONCATENATED_WORLD_POSIX_VAR'
         # test replace from environ taking precedence over file
-        environ["HELLO"] = "TAKES_PRECEDENCE"
+        os.environ["HELLO"] = "TAKES_PRECEDENCE"
         stored_value = dotenv.get_key(dotenv_path, 'FOO')
         assert stored_value == "TAKES_PRECEDENCE"
         sh.rm(dotenv_path)
@@ -194,10 +210,10 @@ def test_get_key_with_interpolation_of_unset_variable(cli):
         stored_value = dotenv.get_key(dotenv_path, 'FOO')
         assert stored_value == ''
         # unless present in environment
-        environ['NOT_SET'] = 'BAR'
+        os.environ['NOT_SET'] = 'BAR'
         stored_value = dotenv.get_key(dotenv_path, 'FOO')
         assert stored_value == 'BAR'
-        del(environ['NOT_SET'])
+        del(os.environ['NOT_SET'])
         sh.rm(dotenv_path)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,7 +9,7 @@ import warnings
 import sh
 
 from dotenv import load_dotenv, find_dotenv, set_key, dotenv_values
-from dotenv.main import Binding, parse_line, parse_stream
+from dotenv.main import Binding, parse_stream
 from dotenv.compat import StringIO
 from IPython.terminal.embed import InteractiveShellEmbed
 
@@ -25,31 +25,64 @@ def restore_os_environ():
 
 
 @pytest.mark.parametrize("test_input,expected", [
-    ("a=b", ("a", "b")),
-    (" a = b ", ("a", "b")),
-    ("export a=b", ("a", "b")),
-    (" export 'a'=b", ("'a'", "b")),
-    (" export 'a'=b", ("'a'", "b")),
-    ("# a=b", (None, None)),
-    ("# a=b", (None, None)),
-    ("a=b space ", ('a', 'b space')),
-    ("a='b space '", ('a', 'b space ')),
-    ('a="b space "', ('a', 'b space ')),
-    ("export export_spam=1", ("export_spam", "1")),
-    ("export port=8000", ("port", "8000")),
-])
-def test_parse_line(test_input, expected):
-    assert parse_line(test_input) == expected
-
-
-@pytest.mark.parametrize("test_input,expected", [
     ("", []),
     ("a=b", [Binding(key="a", value="b", original="a=b")]),
+    ("'a'=b", [Binding(key="'a'", value="b", original="'a'=b")]),
+    ("[=b", [Binding(key="[", value="b", original="[=b")]),
+    (" a = b ", [Binding(key="a", value="b", original=" a = b ")]),
+    ("export a=b", [Binding(key="a", value="b", original="export a=b")]),
+    (" export 'a'=b", [Binding(key="'a'", value="b", original=" export 'a'=b")]),
+    (" export 'a'=b", [Binding(key="'a'", value="b", original=" export 'a'=b")]),
+    ("# a=b", [Binding(key=None, value=None, original="# a=b")]),
+    ('a=b # comment', [Binding(key="a", value="b", original="a=b # comment")]),
+    ("a=b space ", [Binding(key="a", value="b space", original="a=b space ")]),
+    ("a='b space '", [Binding(key="a", value="b space ", original="a='b space '")]),
+    ('a="b space "', [Binding(key="a", value="b space ", original='a="b space "')]),
+    ("export export_a=1", [Binding(key="export_a", value="1", original="export export_a=1")]),
+    ("export port=8000", [Binding(key="port", value="8000", original="export port=8000")]),
+    ('a="b\nc"', [Binding(key="a", value="b\nc", original='a="b\nc"')]),
+    ("a='b\nc'", [Binding(key="a", value="b\nc", original="a='b\nc'")]),
+    ('a="b\nc"', [Binding(key="a", value="b\nc", original='a="b\nc"')]),
+    ('a="b\\nc"', [Binding(key="a", value='b\nc', original='a="b\\nc"')]),
+    ('a="b\\"c"', [Binding(key="a", value='b"c', original='a="b\\"c"')]),
+    ("a='b\\'c'", [Binding(key="a", value="b'c", original="a='b\\'c'")]),
+    ("a=à", [Binding(key="a", value="à", original="a=à")]),
+    ('a="à"', [Binding(key="a", value="à", original='a="à"')]),
+    ('garbage', [Binding(key=None, value=None, original="garbage")]),
     (
         "a=b\nc=d",
         [
             Binding(key="a", value="b", original="a=b\n"),
             Binding(key="c", value="d", original="c=d"),
+        ],
+    ),
+    (
+        "a=b\r\nc=d",
+        [
+            Binding(key="a", value="b", original="a=b\r\n"),
+            Binding(key="c", value="d", original="c=d"),
+        ],
+    ),
+    (
+        'a="\nb=c',
+        [
+            Binding(key="a", value='"', original='a="\n'),
+            Binding(key="b", value='c', original="b=c"),
+        ]
+    ),
+    (
+        '# comment\na="b\nc"\nd=e\n',
+        [
+            Binding(key=None, value=None, original="# comment\n"),
+            Binding(key="a", value="b\nc", original='a="b\nc"\n'),
+            Binding(key="d", value="e", original="d=e\n"),
+        ],
+    ),
+    (
+        'garbage[%$#\na=b',
+        [
+            Binding(key=None, value=None, original="garbage[%$#\n"),
+            Binding(key="a", value="b", original='a=b'),
         ],
     ),
 ])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,7 +9,7 @@ import warnings
 import sh
 
 from dotenv import load_dotenv, find_dotenv, set_key, dotenv_values
-from dotenv.main import parse_line
+from dotenv.main import Binding, parse_line, parse_stream
 from dotenv.compat import StringIO
 from IPython.terminal.embed import InteractiveShellEmbed
 
@@ -40,6 +40,23 @@ def restore_os_environ():
 ])
 def test_parse_line(test_input, expected):
     assert parse_line(test_input) == expected
+
+
+@pytest.mark.parametrize("test_input,expected", [
+    ("", []),
+    ("a=b", [Binding(key="a", value="b", original="a=b")]),
+    (
+        "a=b\nc=d",
+        [
+            Binding(key="a", value="b", original="a=b\n"),
+            Binding(key="c", value="d", original="c=d"),
+        ],
+    ),
+])
+def test_parse_stream(test_input, expected):
+    result = parse_stream(StringIO(test_input))
+
+    assert list(result) == expected
 
 
 def test_warns_if_file_does_not_exist():


### PR DESCRIPTION
This adds support for:

* multiline values (i.e. containing newlines or escaped \n), fixes #89
* backslashes in values, fixes #112
* trailing comments, fixes #141
* UTF-8 in unquoted values, fixes #147

This supersedes a previous pull-request, #142, which would add support for
multiline values in `Dotenv.parse` but not in the CLI (`dotenv get` and `dotenv
set`).

The internal change is significant but I have added a lot of test cases to reduce the risk of breaking anything.  Previous test cases are still present, so I wouldn't expect any major backward incompatibility.

I have written detailed commit messages and made my code as clear as possible.  Let me know if anything should be improved.  I'll be happy to fix anything unsatisfactory.