### PR TITLE
Drop Python 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
   - '2.7'
-  - '3.3'
   - '3.4'
   - '3.5'
   - '3.6'


### PR DESCRIPTION
Remove python 3.3 environment in travis config file.