### PR TITLE
Special __file__ handling for Python 2 (fixes #130)

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -288,7 +288,14 @@ def find_dotenv(filename='.env', raise_error_if_not_found=False, usecwd=False):
         # will work for .py files
         frame = sys._getframe()
         # find first frame that is outside of this file
-        while frame.f_code.co_filename == __file__:
+        if PY2 and not __file__.endswith('.py'):
+            # in Python2 __file__ extension could be .pyc or .pyo (this doesn't account
+            # for edge case of Python compiled for non-standard extension)
+            current_file = __file__.rsplit('.', 1)[0] + '.py'
+        else:
+            current_file = __file__
+
+        while frame.f_code.co_filename == current_file:
             frame = frame.f_back
         frame_filename = frame.f_code.co_filename
         path = os.path.dirname(os.path.abspath(frame_filename))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -174,7 +174,6 @@ def test_load_dotenv_override(tmp_path):
     assert os.environ[key_name] == 'WORKS'
 
 
-@pytest.mark.xfail(sys.version_info < (3, 0), reason="test was incomplete")
 def test_load_dotenv_in_current_dir(tmp_path):
     dotenv_path = tmp_path / '.env'
     dotenv_path.write_bytes(b'a=b')


### PR DESCRIPTION
In Python 2 the extension returned by `__file__` can be either `.pyc` or `.pyo` in addition to `.py`, which means #109 does not always work in Python 2.

This fixes #130 and might be related to #124.

I added the `current_file` variable because modifying `__file__` didn't seem like a good idea (if it's even possible, I didn't try it).