### PR TITLE
Deleted some temporary files that CLI tests were creating

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -208,6 +208,7 @@ def test_run(cli):
         dotenv.set_key(dotenv_path, 'FOO', 'BAR')
         result = sh.dotenv('run', 'printenv', 'FOO').strip()
         assert result == 'BAR'
+        sh.rm(dotenv_path)
 
 
 def test_run_with_other_env(cli):
@@ -218,6 +219,7 @@ def test_run_with_other_env(cli):
         sh.dotenv('--file', DOTENV_FILE, 'set', 'FOO', 'BAR')
         result = sh.dotenv('--file', DOTENV_FILE, 'run', 'printenv', 'FOO').strip()
         assert result == 'BAR'
+        sh.rm(DOTENV_FILE)
 
 
 def test_run_without_cmd(cli):


### PR DESCRIPTION
While working on another PR I noticed that running the test suite was leaving a `tests/dotenv` file.  There appeared to be two test functions that were creating that file but not deleting it when done.