### PR TITLE
Make DotEnv support `sys.stdin`

### DIFF
--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -97,7 +97,9 @@ class DotEnv():
 
     @contextmanager
     def _get_stream(self):
-        if isinstance(self.dotenv_path, StringIO):
+        if hasattr(self.dotenv_path, 'read'):
+            # the dotenv_path implements a read method and is likely a stream.
+            # StringIO or sys.stdin, file objects from open(), etc
             yield self.dotenv_path
         elif os.path.isfile(self.dotenv_path):
             with io.open(self.dotenv_path) as stream:


### PR DESCRIPTION
Make DotEnv support `sys.stdin` which is useful for piping a `.env` formatted stream into an application.