### PR TITLE
Fix parsing of variable without a value

### DIFF
--- a/dotenv/main.py
+++ b/dotenv/main.py
@@ -21,14 +21,14 @@ _binding = re.compile(
     r"""
         (
             \s*                     # leading whitespace
-            (?:export\s+)?          # export
+            (?:export{0}+)?         # export
 
             ( '[^']+'               # single-quoted key
             | [^=\#\s]+             # or unquoted key
             )?
 
             (?:
-                (?:\s*=\s*)         # equal sign
+                (?:{0}*={0}*)       # equal sign
 
                 ( '(?:\\'|[^'])*'   # single-quoted value
                 | "(?:\\"|[^"])*"   # or double-quoted value
@@ -40,7 +40,7 @@ _binding = re.compile(
             (?:\#[^\r\n]*)?         # comment
             (?:\r|\n|\r\n)?         # newline
         )
-    """,
+    """.format(r'[^\S\r\n]'),
     re.MULTILINE | re.VERBOSE,
 )
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -64,6 +64,13 @@ def restore_os_environ():
         ],
     ),
     (
+        'a=\nb=c',
+        [
+            Binding(key="a", value='', original='a=\n'),
+            Binding(key="b", value='c', original="b=c"),
+        ]
+    ),
+    (
         'a="\nb=c',
         [
             Binding(key="a", value='"', original='a="\n'),


### PR DESCRIPTION
In Python, `\s` also matches newlines.  This would cause newlines to be
consumed by the equal sign matcher, resulting in the next line being
considered as a value.

For instance, the following would be parsed as `[("FOO", "BAR=b")]`
instead of `[("FOO", ""), ("BAR", "b")]`.

```bash
FOO=
BAR=b
```

Fixes #157.