### PR TITLE
Isolate test files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-flake8>=2.2.3
-pytest>=3.0.5
-sh>=1.09
 bumpversion
-wheel
-pytest-cov
 click
+flake8>=2.2.3
 ipython
 pypandoc
+pytest-cov
+pytest>=3.9
+sh>=1.09
+wheel

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,14 @@
 import pytest
-
-from .fixtures import *  # noqa
+from click.testing import CliRunner
 
 
 @pytest.fixture
-def dotenv_file(tmpdir):
-    file_ = tmpdir.mkdir('dotenv_file').join('.env')
-    file_.write('')
-    return str(file_)
+def cli():
+    yield CliRunner()
+
+
+@pytest.fixture
+def dotenv_file(tmp_path):
+    file_ = tmp_path / '.env'
+    file_.write_bytes(b'')
+    yield str(file_)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,7 +1,0 @@
-import pytest
-from click.testing import CliRunner
-
-
-@pytest.fixture()
-def cli():
-    return CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-from os.path import dirname, join
 
 import pytest
 import sh
@@ -9,18 +8,14 @@ import dotenv
 from dotenv.cli import cli as dotenv_cli
 from dotenv.version import __version__
 
-here = dirname(__file__)
-dotenv_path = join(here, '.env')
 
-
-def test_get_key():
-    sh.touch(dotenv_path)
-    success, key_to_set, value_to_set = dotenv.set_key(dotenv_path, 'HELLO', 'WORLD')
-    stored_value = dotenv.get_key(dotenv_path, 'HELLO')
+def test_get_key(dotenv_file):
+    success, key_to_set, value_to_set = dotenv.set_key(dotenv_file, 'HELLO', 'WORLD')
+    stored_value = dotenv.get_key(dotenv_file, 'HELLO')
     assert stored_value == 'WORLD'
-    sh.rm(dotenv_path)
-    assert dotenv.get_key(dotenv_path, 'HELLO') is None
-    success, key_to_set, value_to_set = dotenv.set_key(dotenv_path, 'HELLO', 'WORLD')
+    sh.rm(dotenv_file)
+    assert dotenv.get_key(dotenv_file, 'HELLO') is None
+    success, key_to_set, value_to_set = dotenv.set_key(dotenv_file, 'HELLO', 'WORLD')
     assert success is None
 
 
@@ -76,66 +71,52 @@ def test_list_wo_file(cli):
     assert 'Invalid value for "-f"' in result.output
 
 
-def test_empty_value():
-    with open(dotenv_path, "w") as f:
+def test_empty_value(dotenv_file):
+    with open(dotenv_file, "w") as f:
         f.write("TEST=")
-    assert dotenv.get_key(dotenv_path, "TEST") == ""
-    sh.rm(dotenv_path)
+    assert dotenv.get_key(dotenv_file, "TEST") == ""
 
 
-def test_key_value_without_quotes():
-    with open(dotenv_path, 'w') as f:
+def test_key_value_without_quotes(dotenv_file):
+    with open(dotenv_file, 'w') as f:
         f.write("TEST = value \n")
-    assert dotenv.get_key(dotenv_path, 'TEST') == "value"
-    sh.rm(dotenv_path)
+    assert dotenv.get_key(dotenv_file, 'TEST') == "value"
 
-    with open(dotenv_path, 'w') as f:
+
+def test_key_value_without_quotes_with_spaces(dotenv_file):
+    with open(dotenv_file, 'w') as f:
         f.write('TEST = " with spaces " \n')
-    assert dotenv.get_key(dotenv_path, 'TEST') == " with spaces "
-    sh.rm(dotenv_path)
+    assert dotenv.get_key(dotenv_file, 'TEST') == " with spaces "
 
 
-def test_value_with_quotes():
-    with open(dotenv_path, 'w') as f:
+def test_value_with_double_quotes(dotenv_file):
+    with open(dotenv_file, 'w') as f:
         f.write('TEST="two words"\n')
-    assert dotenv.get_key(dotenv_path, 'TEST') == 'two words'
-    sh.rm(dotenv_path)
+    assert dotenv.get_key(dotenv_file, 'TEST') == 'two words'
 
-    with open(dotenv_path, 'w') as f:
+
+def test_value_with_simple_quotes(dotenv_file):
+    with open(dotenv_file, 'w') as f:
         f.write("TEST='two words'\n")
-    assert dotenv.get_key(dotenv_path, 'TEST') == 'two words'
-    sh.rm(dotenv_path)
+    assert dotenv.get_key(dotenv_file, 'TEST') == 'two words'
 
 
-def test_value_with_special_characters():
-    with open(dotenv_path, 'w') as f:
+def test_value_with_special_characters(dotenv_file):
+    with open(dotenv_file, 'w') as f:
         f.write(r'TEST="}=&~{,(\5%{&;"')
-    assert dotenv.get_key(dotenv_path, 'TEST') == r'}=&~{,(\5%{&;'
-    sh.rm(dotenv_path)
-
-    with open(dotenv_path, 'w') as f:
-        f.write(r"TEST='}=&~{,(\5%{&;'")
-    assert dotenv.get_key(dotenv_path, 'TEST') == r'}=&~{,(\5%{&;'
-    sh.rm(dotenv_path)
+    assert dotenv.get_key(dotenv_file, 'TEST') == r'}=&~{,(\5%{&;'
 
 
-def test_value_with_new_lines():
-    with open(dotenv_path, 'w') as f:
+def test_value_with_new_lines(dotenv_file):
+    with open(dotenv_file, 'w') as f:
         f.write('TEST="a\nb"')
-    assert dotenv.get_key(dotenv_path, 'TEST') == "a\nb"
-    sh.rm(dotenv_path)
-
-    with open(dotenv_path, 'w') as f:
-        f.write("TEST='a\nb'")
-    assert dotenv.get_key(dotenv_path, 'TEST') == "a\nb"
-    sh.rm(dotenv_path)
+    assert dotenv.get_key(dotenv_file, 'TEST') == "a\nb"
 
 
-def test_value_after_comment():
-    with open(dotenv_path, "w") as f:
+def test_value_after_comment(dotenv_file):
+    with open(dotenv_file, "w") as f:
         f.write("# comment\nTEST=a")
-    assert dotenv.get_key(dotenv_path, "TEST") == "a"
-    sh.rm(dotenv_path)
+    assert dotenv.get_key(dotenv_file, "TEST") == "a"
 
 
 def test_unset_ok(dotenv_file):
@@ -148,7 +129,6 @@ def test_unset_ok(dotenv_file):
     assert key_to_unset == "a"
     with open(dotenv_file, "r") as f:
         assert f.read() == "c=d"
-    sh.rm(dotenv_file)
 
 
 def test_unset_non_existing_file():
@@ -168,105 +148,104 @@ def test_unset_cli(cli, dotenv_file):
     assert result.exit_code == 1, result.output
 
 
-def test_console_script(cli):
-    TEST_COMBINATIONS = (
-        # quote_mode, var_name, var_value, expected_result
+@pytest.mark.parametrize(
+    "quote_mode,variable,value,expected",
+    (
         ("always", "HELLO", "WORLD", 'HELLO="WORLD"\n'),
         ("never", "HELLO", "WORLD", 'HELLO=WORLD\n'),
         ("auto", "HELLO", "WORLD", 'HELLO=WORLD\n'),
         ("auto", "HELLO", "HELLO WORLD", 'HELLO="HELLO WORLD"\n'),
     )
-    with cli.isolated_filesystem():
-        for quote_mode, variable, value, expected_result in TEST_COMBINATIONS:
-            sh.touch(dotenv_path)
-            sh.dotenv('-f', dotenv_path, '-q', quote_mode, 'set', variable, value)
-            output = sh.cat(dotenv_path)
-            assert output == expected_result
-            sh.rm(dotenv_path)
+)
+def test_console_script(quote_mode, variable, value, expected, dotenv_file):
+    sh.dotenv('-f', dotenv_file, '-q', quote_mode, 'set', variable, value)
 
-    # should fail for not existing file
+    result = sh.cat(dotenv_file)
+
+    assert result == expected
+
+
+def test_set_non_existing_file(cli):
     result = cli.invoke(dotenv.cli.set, ['my_key', 'my_value'])
+
     assert result.exit_code != 0
 
-    # should fail for not existing file
+
+def test_get_non_existing_file(cli):
     result = cli.invoke(dotenv.cli.get, ['my_key'])
-    assert result.exit_code != 0
 
-    # should fail for not existing file
-    result = cli.invoke(dotenv.cli.list, [])
     assert result.exit_code != 0
 
 
-def test_default_path(cli):
-    with cli.isolated_filesystem():
-        sh.touch(dotenv_path)
-        sh.cd(here)
-        sh.dotenv('set', 'HELLO', 'WORLD')
-        output = sh.dotenv('get', 'HELLO')
-        assert output == 'HELLO=WORLD\n'
-        sh.rm(dotenv_path)
+def test_list_non_existing_file(cli):
+    result = cli.invoke(dotenv.cli.set, [])
+
+    assert result.exit_code != 0
 
 
-def test_get_key_with_interpolation(cli):
-    with cli.isolated_filesystem():
-        sh.touch(dotenv_path)
-        dotenv.set_key(dotenv_path, 'HELLO', 'WORLD')
-        dotenv.set_key(dotenv_path, 'FOO', '${HELLO}')
-        dotenv.set_key(dotenv_path, 'BAR', 'CONCATENATED_${HELLO}_POSIX_VAR')
+def test_default_path(tmp_path):
+    sh.cd(str(tmp_path))
+    sh.touch(tmp_path / '.env')
+    sh.dotenv('set', 'HELLO', 'WORLD')
 
-        lines = list(open(dotenv_path, "r").readlines())
-        assert lines == [
-            'HELLO="WORLD"\n',
-            'FOO="${HELLO}"\n',
-            'BAR="CONCATENATED_${HELLO}_POSIX_VAR"\n',
-        ]
+    result = sh.dotenv('get', 'HELLO')
 
-        # test replace from variable in file
-        stored_value = dotenv.get_key(dotenv_path, 'FOO')
-        assert stored_value == 'WORLD'
-        stored_value = dotenv.get_key(dotenv_path, 'BAR')
-        assert stored_value == 'CONCATENATED_WORLD_POSIX_VAR'
-        # test replace from environ taking precedence over file
-        os.environ["HELLO"] = "TAKES_PRECEDENCE"
-        stored_value = dotenv.get_key(dotenv_path, 'FOO')
-        assert stored_value == "TAKES_PRECEDENCE"
-        sh.rm(dotenv_path)
+    assert result == 'HELLO=WORLD\n'
 
 
-def test_get_key_with_interpolation_of_unset_variable(cli):
-    with cli.isolated_filesystem():
-        sh.touch(dotenv_path)
-        dotenv.set_key(dotenv_path, 'FOO', '${NOT_SET}')
-        # test unavailable replacement returns empty string
-        stored_value = dotenv.get_key(dotenv_path, 'FOO')
-        assert stored_value == ''
-        # unless present in environment
-        os.environ['NOT_SET'] = 'BAR'
-        stored_value = dotenv.get_key(dotenv_path, 'FOO')
-        assert stored_value == 'BAR'
-        del(os.environ['NOT_SET'])
-        sh.rm(dotenv_path)
+def test_get_key_with_interpolation(dotenv_file):
+    sh.touch(dotenv_file)
+    dotenv.set_key(dotenv_file, 'HELLO', 'WORLD')
+    dotenv.set_key(dotenv_file, 'FOO', '${HELLO}')
+    dotenv.set_key(dotenv_file, 'BAR', 'CONCATENATED_${HELLO}_POSIX_VAR')
+
+    lines = list(open(dotenv_file, "r").readlines())
+    assert lines == [
+        'HELLO="WORLD"\n',
+        'FOO="${HELLO}"\n',
+        'BAR="CONCATENATED_${HELLO}_POSIX_VAR"\n',
+    ]
+
+    # test replace from variable in file
+    stored_value = dotenv.get_key(dotenv_file, 'FOO')
+    assert stored_value == 'WORLD'
+    stored_value = dotenv.get_key(dotenv_file, 'BAR')
+    assert stored_value == 'CONCATENATED_WORLD_POSIX_VAR'
+    # test replace from environ taking precedence over file
+    os.environ["HELLO"] = "TAKES_PRECEDENCE"
+    stored_value = dotenv.get_key(dotenv_file, 'FOO')
+    assert stored_value == "TAKES_PRECEDENCE"
 
 
-def test_run(cli):
-    with cli.isolated_filesystem():
-        sh.touch(dotenv_path)
-        sh.cd(here)
-        dotenv.set_key(dotenv_path, 'FOO', 'BAR')
-        result = sh.dotenv('run', 'printenv', 'FOO').strip()
-        assert result == 'BAR'
-        sh.rm(dotenv_path)
+def test_get_key_with_interpolation_of_unset_variable(dotenv_file):
+    dotenv.set_key(dotenv_file, 'FOO', '${NOT_SET}')
+    # test unavailable replacement returns empty string
+    stored_value = dotenv.get_key(dotenv_file, 'FOO')
+    assert stored_value == ''
+    # unless present in environment
+    os.environ['NOT_SET'] = 'BAR'
+    stored_value = dotenv.get_key(dotenv_file, 'FOO')
+    assert stored_value == 'BAR'
+    del(os.environ['NOT_SET'])
 
 
-def test_run_with_other_env(cli):
-    DOTENV_FILE = 'dotenv'
-    with cli.isolated_filesystem():
-        sh.cd(here)
-        sh.touch(DOTENV_FILE)
-        sh.dotenv('--file', DOTENV_FILE, 'set', 'FOO', 'BAR')
-        result = sh.dotenv('--file', DOTENV_FILE, 'run', 'printenv', 'FOO').strip()
-        assert result == 'BAR'
-        sh.rm(DOTENV_FILE)
+def test_run(tmp_path):
+    dotenv_file = tmp_path / '.env'
+    dotenv_file.touch()
+    sh.cd(str(tmp_path))
+    dotenv.set_key(str(dotenv_file), 'FOO', 'BAR')
+    result = sh.dotenv('run', 'printenv', 'FOO').strip()
+    assert result == 'BAR'
+
+
+def test_run_with_other_env(tmp_path):
+    dotenv_name = 'dotenv'
+    dotenv_file = tmp_path / dotenv_name
+    dotenv_file.touch()
+    sh.cd(str(tmp_path))
+    sh.dotenv('--file', dotenv_name, 'set', 'FOO', 'BAR')
+    result = sh.dotenv('--file', dotenv_name, 'run', 'printenv', 'FOO').strip()
+    assert result == 'BAR'
 
 
 def test_run_without_cmd(cli):


### PR DESCRIPTION
The test suite had the following issues:

* A failing test would leave files in the `tests` directory, causing
  other tests to fail unexpectedly.
* Even successful tests would require clean up code like `sh.rm(...)` to
  avoid leaving test files.  This was easy to forget as shown by #153.
* The same test file would be used for several tests, making them unsafe
  to run in parallel.

This commit fixes that by using the `dotenv_file` and `tmp_path`
fixtures whenever the filesystem is required.  The advantage of those
fixtures is that they use unique test directories, which are eventually
cleaned up.

The `tmp_path` fixture is preferred to the `tmpdir` fixture because
`tmpdir` relies on `py.path`, a library in "maintenance mode".