### PR TITLE
Custom getenv method

### DIFF
--- a/src/dotenv/__init__.py
+++ b/src/dotenv/__init__.py
@@ -1,4 +1,4 @@
-from .main import load_dotenv, get_key, set_key, unset_key, find_dotenv, dotenv_values
+from .main import load_dotenv, get_key, set_key, unset_key, find_dotenv, dotenv_values, getenv
 
 
 def load_ipython_extension(ipython):
@@ -37,4 +37,5 @@ __all__ = ['get_cli_string',
            'set_key',
            'unset_key',
            'find_dotenv',
-           'load_ipython_extension']
+           'load_ipython_extension',
+           'getenv']

--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -353,3 +353,52 @@ def run_command(command, env):
     _, _ = p.communicate()
 
     return p.returncode
+
+
+def getenv(key, default=None, delimiter=','):
+    '''A wrapper to os.getenv. Loads key from the envs. If key is
+    not found from the envs, default will be returned. Additionally,
+    this utilizes the datatype of default, the returned value will be
+    cast to the type of given default.
+
+    when default is:
+        None - no casting will be done, return value is str
+        boolean - return value would be translated to boolean
+        list (or tuple) - env value split using delimiter, and returned
+            as list or tuple
+        numeric - return value is cast to numeric (int or float)
+        str - return value is string
+    '''
+
+    value = os.environ.get(key, default)
+
+    if isinstance(default, bool):
+        # if the default value is a boolean, this function will return
+        # True or False. None is not allowed and will raise an exception
+        if isinstance(value, bool):
+            return value
+
+        elif value.lower() in ['true', '1']:
+            return True
+
+        elif value.lower() in ['false', '0']:
+            return False
+
+        else:
+            raise ValueError(
+                'Error loading env. %s cannot be translated to boolean' % key)
+
+    elif isinstance(default, list) or isinstance(default, tuple):
+        # if the default value is a list or tuple, cast value to
+        # list or tuple by splitting on the delimiter
+        if isinstance(value, str):
+            value = value.split(delimiter)
+
+    if value is not None:
+        # cast type of value to type of default (if it is not None)
+        if default is not None:
+            return type(default)(value)
+
+        return value
+
+    raise ValueError('Env variable %s not found' % key)


### PR DESCRIPTION
Together with dotenv, I've been using this custom `getenv` method for most of my web projects, and may be an additional value to dotenv. this custom `getenv` is a wrapper to `os.getenv` that casts datatype of the loaded env to the type of default.

consider this settings.py
```
# sample settings.py
import os
from dotenv import load_dotenv

load_dotenv()

LOG_FILE_SIZE = int(os.getenv('LOG_FILE_SIZE', 50))            # we have to cast to int
DEBUG = os.getenv('DEBUG', 'False') == 'True'                  # we have to check equality
ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', '').split(',')      # we have to split
```

Since `os.getenv` returns a string, developers have to cast into the desired type or do postprocessing inside the settings.py. This adds noise to the settings file.

It would be much concise and cleaner when using the custom `getenv`. The sample settings.py above, using `getenv` will now be

```
# improved settings.py
from dotenv import load_dotenv, getenv

load_dotenv()

LOG_FILE_SIZE = getenv('LOG_FILE_SIZE', 50))      # returns int
DEBUG = getenv('DEBUG', False)                    # returns boolean
ALLOWED_HOSTS = getenv('ALLOWED_HOSTS', [])       # returns list split by comma

```

**getenv** casts the output of os.getenv to the type of the given default. for list / tuple defaults, getenv splits the env string using a delimiter, similar to

```
ALLOWED_HOSTS = getenv('ALLOWED_HOSTS', (), delimiter=':')       # returns tuple split by colon
```

additionally, errors will be raised when the expected values cannot be cast to the default type. In the example below, a `ValueError` will be raised since string __'invalid file size'__ cannot be cast to int.

```
# .env file
LOG_FILE_SIZE='invalid file size'

# settings.py
LOG_FILE_SIZE = getenv('LOG_FILE_SIZE', 50)
```