### PR TITLE
Adding Dynaconf to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Related Projects
 -   [django-configuration](https://github.com/jezdez/django-configurations)
 -   [dump-env](https://github.com/sobolevn/dump-env)
 -   [environs](https://github.com/sloria/environs)
+-   [dynaconf](https://github.com/rochacbruno/dynaconf)
 
 Contributing
 ============


### PR DESCRIPTION
HI,

Dynaconf heavily uses `python-dotenv` 

https://dynaconf.readthedocs.io

https://github.com/rochacbruno/dynaconf