### PR TITLE
Fix unicode/str inconsistency in Python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,10 @@ Unreleased
 -----
 
 - Add type hints and expose them to users ([@qnighy])([#172])
-- `load_dotenv` and `dotenv_values` now accepts `encoding` paramater, defaults to `None` ([@theskumar])([@earlbread]) (#161)
+- `load_dotenv` and `dotenv_values` now accept an `encoding` parameter, defaults to `None`
+  ([@theskumar])([@earlbread])([#161])
+- Fix `str`/`unicode` inconsistency in Python 2: values are always `str` now. ([@bbc2])([#121])
+- Fix Unicode error in Python 2, introduced in 0.10.0. ([@bbc2])([#176])
 
 0.10.1
 -----
@@ -417,6 +420,8 @@ Unreleased
 [#148]: https://github.com/theskumar/python-dotenv/issues/148
 [#158]: https://github.com/theskumar/python-dotenv/issues/158
 [#172]: https://github.com/theskumar/python-dotenv/issues/172
+[#121]: https://github.com/theskumar/python-dotenv/issues/121
+[#176]: https://github.com/theskumar/python-dotenv/issues/176
 
 [@asyncee]: https://github.com/asyncee
 [@greyli]: https://github.com/greyli

--- a/src/dotenv/compat.py
+++ b/src/dotenv/compat.py
@@ -1,10 +1,8 @@
-from typing import Text, Type
 import sys
+
 if sys.version_info >= (3, 0):
     from io import StringIO  # noqa
 else:
     from StringIO import StringIO  # noqa
 
 PY2 = sys.version_info[0] == 2  # type: bool
-WIN = sys.platform.startswith('win')  # type: bool
-text_type = Text  # type: Type[Text]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,7 +12,7 @@ import sh
 from IPython.terminal.embed import InteractiveShellEmbed
 
 from dotenv import dotenv_values, find_dotenv, load_dotenv, set_key
-from dotenv.compat import StringIO
+from dotenv.compat import PY2, StringIO
 from dotenv.main import Binding, parse_stream
 
 
@@ -227,6 +227,15 @@ def test_dotenv_values_export():
     load_dotenv(stream=stream)
     assert 'foo' in os.environ
     assert os.environ['foo'] == 'bar'
+
+
+def test_dotenv_values_utf_8():
+    stream = StringIO(u"a=à\n")
+    load_dotenv(stream=stream)
+    if PY2:
+        assert os.environ["a"] == u"à".encode(sys.getfilesystemencoding())
+    else:
+        assert os.environ["a"] == "à"
 
 
 def test_dotenv_empty_selfreferential_interpolation():


### PR DESCRIPTION
This encodes environment keys and values for `os.environ` in Python 2
and fixes the following issues:

* Values loaded from `.env` being `unicode` whereas regular values being
  `str` (i.e. `bytes`) in Python 2.
* Error when loading `.env` with UTF-8 characters in Python 2.
* `# type: ignore` hiding the issue from the type checker.

`sys.getfilesystemencoding()` is used because it seems to match the
encoding used for environment variables with Python 2.  Since it can
apparently return `None`, we fall back to a default encoding (UTF-8
here) if that's the case.

I tested this on Windows where `"mbcs"` is the file system encoding.
Hopefully, this will also work on other systems.

Closes #121. Closes #176.