### PR TITLE
for the default encoding of python3

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -37,7 +37,13 @@ class DotEnv():
         self.dotenv_path = dotenv_path  # type: Union[Text,_PathLike, _StringIO]
         self._dict = None  # type: Optional[Dict[Text, Text]]
         self.verbose = verbose  # type: bool
-        self.encoding = encoding  # type: Union[None, Text]
+
+        # for the default encoding of python3
+        if PY2:
+            self.encoding = encoding  # type: Union[None, Text]
+        else:
+            self.encoding = 'utf-8'
+
 
     @contextmanager
     def _get_stream(self):


### PR DESCRIPTION
While under windows 10, I have got this error:
```
File "J:\測試\venv\lib\site-packages\dotenv\parser.py", line 41, in __init__
    self.string = stream.read()
UnicodeDecodeError: 'cp950' codec can't decode byte 0x98 in position 4: illegal multibyte sequence
```
I think dotenv try to get project path by 
```
path = os.getcwd()
```
and under python3, the default encoding is utf-8.

Would you please modify the constructor of DotEnv() for us as below:
```
def __init__(self, dotenv_path, verbose=False, encoding=None):
	# type: (Union[Text, _PathLike, _StringIO], bool, Union[None, Text]) -> None
	self.dotenv_path = dotenv_path  # type: Union[Text,_PathLike, _StringIO]
	self._dict = None  # type: Optional[Dict[Text, Text]]
	self.verbose = verbose  # type: bool
	# self.encoding = encoding  # type: Union[None, Text] # <------ comment this line as change it as follows.
	if PY2:
		self.encoding = encoding  # type: Union[None, Text]
	else:
		self.encoding = 'utf-8'
```
 Thanks  for your help.