### PR TITLE
Allow more filelike objects to be used as stream input

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -37,7 +37,7 @@ class DotEnv():
         self.dotenv_path = dotenv_path  # type: Union[Text,_PathLike, _StringIO]
         self._dict = None  # type: Optional[Dict[Text, Text]]
         self.verbose = verbose  # type: bool
-        self.encoding = encoding  # type: Union[None, Text]
+        self.encoding = encoding or sys.getfilesystemencoding() or 'utf-8'  # type: Union[None, Text]
 
     @contextmanager
     def _get_stream(self):

--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -42,7 +42,7 @@ class DotEnv():
     @contextmanager
     def _get_stream(self):
         # type: () -> Iterator[IO[Text]]
-        if isinstance(self.dotenv_path, StringIO):
+        if hasattr(self.dotenv_path, "read"):
             yield self.dotenv_path
         elif os.path.isfile(self.dotenv_path):
             with io.open(self.dotenv_path, encoding=self.encoding) as stream:

--- a/src/dotenv/parser.py
+++ b/src/dotenv/parser.py
@@ -38,6 +38,10 @@ class Reader:
     def __init__(self, stream):
         # type: (IO[Text]) -> None
         self.string = stream.read()
+        if not isinstance(self.string, str):
+            message = ("Expected contents of type 'str'. ",
+                       "Received contents of type '%s'.")
+            raise TypeError(message % type(self.string).__name__)
         self.position = 0
         self.mark = 0
 

--- a/src/dotenv/parser.py
+++ b/src/dotenv/parser.py
@@ -1,5 +1,6 @@
 import codecs
 import re
+import sys
 from typing import (IO, Iterator, Match, NamedTuple, Optional, Pattern,  # noqa
                     Sequence, Text)
 
@@ -37,11 +38,11 @@ class Error(Exception):
 class Reader:
     def __init__(self, stream):
         # type: (IO[Text]) -> None
-        self.string = stream.read()
-        if not isinstance(self.string, str):
-            message = ("Expected contents of type 'str'. ",
-                       "Received contents of type '%s'.")
-            raise TypeError(message % type(self.string).__name__)
+        contents = stream.read()
+        # Convert stream contents to unicode if needed
+        if not isinstance(contents, Text):
+            contents = contents.decode(sys.getfilesystemencoding() or "utf-8")
+        self.string = contents
         self.position = 0
         self.mark = 0
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -145,6 +145,26 @@ def test_dotenv_values_stream():
     assert parsed_dict['DOTENV'] == u'it works!😃'
 
 
+def test_dotenv_values_file(tmp_path):
+    dotenv_path = tmp_path / '.test_open_file_stream'
+    sh.touch(dotenv_path)
+    sys_encoding = sys.getfilesystemencoding()
+    with open(str(dotenv_path), 'w', encoding=sys_encoding) as stream:
+        stream.write(u'stream_file="working😃"')
+
+    # test file opened normally
+    with open(str(dotenv_path), encoding=sys_encoding) as stream:
+        parsed_dict = dotenv_values(stream=stream)
+        assert 'stream_file' in parsed_dict
+        assert parsed_dict['stream_file'] == 'working😃'
+
+    # test file opened in raw mode
+    with open(str(dotenv_path), 'rb') as stream:
+        parsed_dict = dotenv_values(stream=stream)
+        assert 'stream_file' in parsed_dict
+        assert parsed_dict['stream_file'] == 'working😃'
+
+
 def test_dotenv_values_export():
     stream = StringIO('export foo=bar\n')
     stream.seek(0)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -149,20 +149,21 @@ def test_dotenv_values_file(tmp_path):
     dotenv_path = tmp_path / '.test_open_file_stream'
     sh.touch(dotenv_path)
     sys_encoding = sys.getfilesystemencoding()
-    with open(str(dotenv_path), 'w', encoding=sys_encoding) as stream:
-        stream.write(u'stream_file="working😃"')
+    expected_read_value = u'working😃'.encode('utf-8').decode(sys_encoding)
+    with io.open(str(dotenv_path), 'w', encoding='utf-8') as stream:
+        stream.write(u'stream_file="working😃"\n')
 
     # test file opened normally
-    with open(str(dotenv_path), encoding=sys_encoding) as stream:
+    with io.open(str(dotenv_path), encoding=sys_encoding) as stream:
         parsed_dict = dotenv_values(stream=stream)
         assert 'stream_file' in parsed_dict
-        assert parsed_dict['stream_file'] == 'working😃'
+        assert parsed_dict['stream_file'] == expected_read_value
 
     # test file opened in raw mode
-    with open(str(dotenv_path), 'rb') as stream:
+    with io.open(str(dotenv_path), 'rb') as stream:
         parsed_dict = dotenv_values(stream=stream)
         assert 'stream_file' in parsed_dict
-        assert parsed_dict['stream_file'] == 'working😃'
+        assert parsed_dict['stream_file'] == expected_read_value
 
 
 def test_dotenv_values_export():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import contextlib
+import io
 import os
 import sys
 import textwrap


### PR DESCRIPTION
Allows open file objects (and other filelike objects) to be used as a stream.

For example, using an open file as a stream passes a type of `io.TextIOWrapper` to `_get_stream`, which would previously fail as not being a `StringIO` (a `TypeError` was then raised at the call to `os.path.isfile`). Instead, `hasattr(self.dotenv_path, "read")` is now used for compatibility with more io types. Verification of it as a text stream is added to the `parser.Reader.__init__` after calling `stream.read()`.