### PR TITLE
Print warning on malformed lines in .env file

### DIFF
--- a/src/dotenv/parser.py
+++ b/src/dotenv/parser.py
@@ -154,10 +154,7 @@ def parse_binding(reader):
 
 
 def parse_stream(stream):
-    # type:(IO[Text]) -> Iterator[Binding]
+    # type: (IO[Text]) -> Iterator[Binding]
     reader = Reader(stream)
     while reader.has_next():
-        try:
-            yield parse_binding(reader)
-        except Error:
-            return
+        yield parse_binding(reader)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,83 +2,95 @@
 import pytest
 
 from dotenv.compat import StringIO
-from dotenv.parser import Binding, parse_stream
+from dotenv.parser import Binding, Original, parse_stream
 
 
 @pytest.mark.parametrize("test_input,expected", [
     (u"", []),
-    (u"a=b", [Binding(key=u"a", value=u"b", original=u"a=b")]),
-    (u"'a'=b", [Binding(key=u"a", value=u"b", original=u"'a'=b")]),
-    (u"[=b", [Binding(key=u"[", value=u"b", original=u"[=b")]),
-    (u" a = b ", [Binding(key=u"a", value=u"b", original=u" a = b ")]),
-    (u"export a=b", [Binding(key=u"a", value=u"b", original=u"export a=b")]),
-    (u" export 'a'=b", [Binding(key=u"a", value=u"b", original=u" export 'a'=b")]),
-    (u"# a=b", [Binding(key=None, value=None, original=u"# a=b")]),
-    (u"a=b#c", [Binding(key=u"a", value=u"b#c", original=u"a=b#c")]),
-    (u'a=b # comment', [Binding(key=u"a", value=u"b", original=u"a=b # comment")]),
-    (u"a=b space ", [Binding(key=u"a", value=u"b space", original=u"a=b space ")]),
-    (u"a='b space '", [Binding(key=u"a", value=u"b space ", original=u"a='b space '")]),
-    (u'a="b space "', [Binding(key=u"a", value=u"b space ", original=u'a="b space "')]),
-    (u"export export_a=1", [Binding(key=u"export_a", value=u"1", original=u"export export_a=1")]),
-    (u"export port=8000", [Binding(key=u"port", value=u"8000", original=u"export port=8000")]),
-    (u'a="b\nc"', [Binding(key=u"a", value=u"b\nc", original=u'a="b\nc"')]),
-    (u"a='b\nc'", [Binding(key=u"a", value=u"b\nc", original=u"a='b\nc'")]),
-    (u'a="b\nc"', [Binding(key=u"a", value=u"b\nc", original=u'a="b\nc"')]),
-    (u'a="b\\nc"', [Binding(key=u"a", value=u'b\nc', original=u'a="b\\nc"')]),
-    (u"a='b\\nc'", [Binding(key=u"a", value=u'b\\nc', original=u"a='b\\nc'")]),
-    (u'a="b\\"c"', [Binding(key=u"a", value=u'b"c', original=u'a="b\\"c"')]),
-    (u"a='b\\'c'", [Binding(key=u"a", value=u"b'c", original=u"a='b\\'c'")]),
-    (u"a=à", [Binding(key=u"a", value=u"à", original=u"a=à")]),
-    (u'a="à"', [Binding(key=u"a", value=u"à", original=u'a="à"')]),
-    (u'garbage', [Binding(key=None, value=None, original=u"garbage")]),
+    (u"a=b", [Binding(key=u"a", value=u"b", original=Original(string=u"a=b", line=1))]),
+    (u"'a'=b", [Binding(key=u"a", value=u"b", original=Original(string=u"'a'=b", line=1))]),
+    (u"[=b", [Binding(key=u"[", value=u"b", original=Original(string=u"[=b", line=1))]),
+    (u" a = b ", [Binding(key=u"a", value=u"b", original=Original(string=u" a = b ", line=1))]),
+    (u"export a=b", [Binding(key=u"a", value=u"b", original=Original(string=u"export a=b", line=1))]),
+    (u" export 'a'=b", [Binding(key=u"a", value=u"b", original=Original(string=u" export 'a'=b", line=1))]),
+    (u"# a=b", [Binding(key=None, value=None, original=Original(string=u"# a=b", line=1))]),
+    (u"a=b#c", [Binding(key=u"a", value=u"b#c", original=Original(string=u"a=b#c", line=1))]),
+    (u'a=b # comment', [Binding(key=u"a", value=u"b", original=Original(string=u"a=b # comment", line=1))]),
+    (u"a=b space ", [Binding(key=u"a", value=u"b space", original=Original(string=u"a=b space ", line=1))]),
+    (u"a='b space '", [Binding(key=u"a", value=u"b space ", original=Original(string=u"a='b space '", line=1))]),
+    (u'a="b space "', [Binding(key=u"a", value=u"b space ", original=Original(string=u'a="b space "', line=1))]),
+    (
+        u"export export_a=1",
+        [
+            Binding(key=u"export_a", value=u"1", original=Original(string=u"export export_a=1", line=1))
+        ],
+    ),
+    (u"export port=8000", [Binding(key=u"port", value=u"8000", original=Original(string=u"export port=8000", line=1))]),
+    (u'a="b\nc"', [Binding(key=u"a", value=u"b\nc", original=Original(string=u'a="b\nc"', line=1))]),
+    (u"a='b\nc'", [Binding(key=u"a", value=u"b\nc", original=Original(string=u"a='b\nc'", line=1))]),
+    (u'a="b\nc"', [Binding(key=u"a", value=u"b\nc", original=Original(string=u'a="b\nc"', line=1))]),
+    (u'a="b\\nc"', [Binding(key=u"a", value=u'b\nc', original=Original(string=u'a="b\\nc"', line=1))]),
+    (u"a='b\\nc'", [Binding(key=u"a", value=u'b\\nc', original=Original(string=u"a='b\\nc'", line=1))]),
+    (u'a="b\\"c"', [Binding(key=u"a", value=u'b"c', original=Original(string=u'a="b\\"c"', line=1))]),
+    (u"a='b\\'c'", [Binding(key=u"a", value=u"b'c", original=Original(string=u"a='b\\'c'", line=1))]),
+    (u"a=à", [Binding(key=u"a", value=u"à", original=Original(string=u"a=à", line=1))]),
+    (u'a="à"', [Binding(key=u"a", value=u"à", original=Original(string=u'a="à"', line=1))]),
+    (u'garbage', [Binding(key=None, value=None, original=Original(string=u"garbage", line=1))]),
     (
         u"a=b\nc=d",
         [
-            Binding(key=u"a", value=u"b", original=u"a=b\n"),
-            Binding(key=u"c", value=u"d", original=u"c=d"),
+            Binding(key=u"a", value=u"b", original=Original(string=u"a=b\n", line=1)),
+            Binding(key=u"c", value=u"d", original=Original(string=u"c=d", line=2)),
+        ],
+    ),
+    (
+        u"a=b\rc=d",
+        [
+            Binding(key=u"a", value=u"b", original=Original(string=u"a=b\r", line=1)),
+            Binding(key=u"c", value=u"d", original=Original(string=u"c=d", line=2)),
         ],
     ),
     (
         u"a=b\r\nc=d",
         [
-            Binding(key=u"a", value=u"b", original=u"a=b\r\n"),
-            Binding(key=u"c", value=u"d", original=u"c=d"),
+            Binding(key=u"a", value=u"b", original=Original(string=u"a=b\r\n", line=1)),
+            Binding(key=u"c", value=u"d", original=Original(string=u"c=d", line=2)),
         ],
     ),
     (
         u'a=\nb=c',
         [
-            Binding(key=u"a", value=u'', original=u'a=\n'),
-            Binding(key=u"b", value=u'c', original=u"b=c"),
+            Binding(key=u"a", value=u'', original=Original(string=u'a=\n', line=1)),
+            Binding(key=u"b", value=u'c', original=Original(string=u"b=c", line=2)),
         ]
     ),
     (
         u'a=b\n\nc=d',
         [
-            Binding(key=u"a", value=u"b", original=u"a=b\n"),
-            Binding(key=u"c", value=u"d", original=u"\nc=d"),
+            Binding(key=u"a", value=u"b", original=Original(string=u"a=b\n", line=1)),
+            Binding(key=u"c", value=u"d", original=Original(string=u"\nc=d", line=2)),
         ]
     ),
     (
         u'a="\nb=c',
         [
-            Binding(key=None, value=None, original=u'a="\n'),
-            Binding(key=u"b", value=u"c", original=u"b=c"),
+            Binding(key=None, value=None, original=Original(string=u'a="\n', line=1)),
+            Binding(key=u"b", value=u"c", original=Original(string=u"b=c", line=2)),
         ]
     ),
     (
         u'# comment\na="b\nc"\nd=e\n',
         [
-            Binding(key=None, value=None, original=u"# comment\n"),
-            Binding(key=u"a", value=u"b\nc", original=u'a="b\nc"\n'),
-            Binding(key=u"d", value=u"e", original=u"d=e\n"),
+            Binding(key=None, value=None, original=Original(string=u"# comment\n", line=1)),
+            Binding(key=u"a", value=u"b\nc", original=Original(string=u'a="b\nc"\n', line=2)),
+            Binding(key=u"d", value=u"e", original=Original(string=u"d=e\n", line=4)),
         ],
     ),
     (
         u'garbage[%$#\na=b',
         [
-            Binding(key=None, value=None, original=u"garbage[%$#\n"),
-            Binding(key=u"a", value=u"b", original=u'a=b'),
+            Binding(key=None, value=None, original=Original(string=u"garbage[%$#\n", line=1)),
+            Binding(key=u"a", value=u"b", original=Original(string=u'a=b', line=2)),
         ],
     ),
 ])


### PR DESCRIPTION
This prints a warning such as the following on stderr (`logging.warning`) when part of the .env file can't be parsed:

```
Python-dotenv could not parse statement starting at line 2
```

I think it's OK to use the "warning" level because such an error means that something should be fixed by the user.

Note that Python-dotenv will continue to parse the file and won't interfere in any other way with the application using it.

I've also added some commits to fix the CI (linting in the code and the manifest).

Fixes #204 