### PR TITLE
Run tests also when typing is absent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       env: TOXENV=py27
     - python: "3.4"
       env: TOXENV=py34
+    - python: "3.4"
+      env: TOXENV=py34-no-typing
     - python: "3.5"
       env: TOXENV=py35
     - python: "3.6"

--- a/src/dotenv/compat.py
+++ b/src/dotenv/compat.py
@@ -12,7 +12,7 @@ def is_type_checking():
     # type: () -> bool
     try:
         from typing import TYPE_CHECKING
-    except ImportError:  # pragma: no cover
+    except ImportError:
         return False
     return TYPE_CHECKING
 

--- a/src/dotenv/parser.py
+++ b/src/dotenv/parser.py
@@ -39,7 +39,7 @@ try:
     Binding = typing.NamedTuple("Binding", [("key", typing.Optional[typing.Text]),
                                             ("value", typing.Optional[typing.Text]),
                                             ("original", typing.Text)])
-except ImportError:  # pragma: no cover
+except ImportError:
     from collections import namedtuple
     Binding = namedtuple("Binding", ["key",  # type: ignore
                                      "value",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,7 +9,6 @@ import warnings
 
 import pytest
 import sh
-from IPython.terminal.embed import InteractiveShellEmbed
 
 from dotenv import dotenv_values, find_dotenv, load_dotenv, set_key
 from dotenv.compat import PY2, StringIO
@@ -117,6 +116,7 @@ def test_load_dotenv_in_current_dir(tmp_path):
 
 
 def test_ipython(tmp_path):
+    from IPython.terminal.embed import InteractiveShellEmbed
     os.chdir(str(tmp_path))
     dotenv_file = tmp_path / '.env'
     dotenv_file.write_text("MYNEWVALUE=q1w2e3\n")
@@ -127,6 +127,7 @@ def test_ipython(tmp_path):
 
 
 def test_ipython_override(tmp_path):
+    from IPython.terminal.embed import InteractiveShellEmbed
     os.chdir(str(tmp_path))
     dotenv_file = tmp_path / '.env'
     os.environ["MYNEWVALUE"] = "OVERRIDE"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py{27,34,35,36,37},pypy,pypy3,manifest,coverage-report
+envlist = lint,py{27,34,35,36,37,34-no-typing},pypy,pypy3,manifest,coverage-report
 
 [testenv]
 deps = 
@@ -8,9 +8,14 @@ deps =
   sh
   click
   py{27,py}: ipython<6.0.0
-  py34: ipython<7.0.0
+  py34{,-no-typing}: ipython<7.0.0
   py{35,36,37,py3}: ipython
 commands = coverage run --parallel -m pytest {posargs}
+
+[testenv:py34-no-typing]
+commands =
+  pip uninstall --yes typing
+  coverage run --parallel -m pytest -k 'not test_ipython' {posargs}
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
The dependency on the `typing` package is now optional for Python 3.4. This commit runs (part of) the test suite when that package is absent, to ensure the dependency isn't reintroduced accidentally.