### PR TITLE
Fix handling of no-value and malformed lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ Changelog
 Latest
 -----
 
-- ...
+- Fix handling of malformed lines and lines without a value:
+  - Don't print warning when key has no value.
+  - Reject more malformed lines (e.g. "A: B").
 
 0.10.4
 -----

--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -37,7 +37,7 @@ __posix_variable = re.compile(r'\$\{[^\}]*\}')  # type: Pattern[Text]
 def with_warn_for_invalid_lines(mappings):
     # type: (Iterator[Binding]) -> Iterator[Binding]
     for mapping in mappings:
-        if mapping.key is None or mapping.value is None:
+        if mapping.key is None:
             logger.warning(
                 "Python-dotenv could not parse statement starting at line %s",
                 mapping.original.line,

--- a/src/dotenv/parser.py
+++ b/src/dotenv/parser.py
@@ -16,16 +16,17 @@ def make_regex(string, extra_flags=0):
 
 
 _newline = make_regex(r"(\r\n|\n|\r)")
-_whitespace = make_regex(r"\s*", extra_flags=re.MULTILINE)
+_multiline_whitespace = make_regex(r"\s*", extra_flags=re.MULTILINE)
+_whitespace = make_regex(r"[^\S\r\n]*")
 _export = make_regex(r"(?:export[^\S\r\n]+)?")
 _single_quoted_key = make_regex(r"'([^']+)'")
 _unquoted_key = make_regex(r"([^=\#\s]+)")
-_equal_sign = make_regex(r"([^\S\r\n]*=[^\S\r\n]*)?")
+_equal_sign = make_regex(r"(=[^\S\r\n]*)")
 _single_quoted_value = make_regex(r"'((?:\\'|[^'])*)'")
 _double_quoted_value = make_regex(r'"((?:\\"|[^"])*)"')
 _unquoted_value_part = make_regex(r"([^ \r\n]*)")
 _comment = make_regex(r"(?:\s*#[^\r\n]*)?")
-_end_of_line = make_regex(r"[^\S\r\n]*(?:\r\n|\n|\r)?")
+_end_of_line = make_regex(r"[^\S\r\n]*(?:\r\n|\n|\r|$)")
 _rest_of_line = make_regex(r"[^\r\n]*(?:\r|\n|\r\n)?")
 _double_quote_escapes = make_regex(r"\\[\\'\"abfnrtv]")
 _single_quote_escapes = make_regex(r"\\[\\']")
@@ -191,11 +192,15 @@ def parse_binding(reader):
     # type: (Reader) -> Binding
     reader.set_mark()
     try:
-        reader.read_regex(_whitespace)
+        reader.read_regex(_multiline_whitespace)
         reader.read_regex(_export)
         key = parse_key(reader)
-        (sign,) = reader.read_regex(_equal_sign)
-        value = parse_value(reader) if sign else None
+        reader.read_regex(_whitespace)
+        if reader.peek(1) == "=":
+            reader.read_regex(_equal_sign)
+            value = parse_value(reader)  # type: Optional[Text]
+        else:
+            value = None
         reader.read_regex(_comment)
         reader.read_regex(_end_of_line)
         return Binding(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -36,6 +36,7 @@ from dotenv.parser import Binding, Original, parse_stream
     (u"a=à", [Binding(key=u"a", value=u"à", original=Original(string=u"a=à", line=1))]),
     (u'a="à"', [Binding(key=u"a", value=u"à", original=Original(string=u'a="à"', line=1))]),
     (u'no_value_var', [Binding(key=u'no_value_var', value=None, original=Original(string=u"no_value_var", line=1))]),
+    (u'a: b', [Binding(key=None, value=None, original=Original(string=u"a: b", line=1))]),
     (
         u"a=b\nc=d",
         [


### PR DESCRIPTION
- Don't print warning when key has no value.
- Reject more malformed lines (e.g. "A: B").