### PR TITLE
Fix dotenv run crashes on variable without values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix escaping of quoted values written by `set_key` (#236 by [@bbc2]).
+- Fix dotenv run crashing on environment variables without values
 
 ## [0.11.0] - 2020-02-07
 

--- a/src/dotenv/cli.py
+++ b/src/dotenv/cli.py
@@ -9,7 +9,7 @@ except ImportError:
                      'Run pip install "python-dotenv[cli]" to fix this.')
     sys.exit(1)
 
-from .compat import IS_TYPE_CHECKING
+from .compat import IS_TYPE_CHECKING, to_env
 from .main import dotenv_values, get_key, set_key, unset_key
 from .version import __version__
 
@@ -97,11 +97,12 @@ def run(ctx, commandline):
     # type: (click.Context, List[str]) -> None
     """Run command with environment variables present."""
     file = ctx.obj['FILE']
-    dotenv_as_dict = dotenv_values(file)
+    dotenv_as_dict = {to_env(k): to_env(v) for (k, v) in dotenv_values(file).items() if v is not None}
+
     if not commandline:
         click.echo('No command given.')
         exit(1)
-    ret = run_command(commandline, dotenv_as_dict)  # type: ignore
+    ret = run_command(commandline, dotenv_as_dict)
     exit(ret)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -121,6 +121,17 @@ def test_run(tmp_path):
     assert result == "b\n"
 
 
+def test_run_with_none_value(tmp_path):
+    sh.cd(str(tmp_path))
+    dotenv_file = str(tmp_path / ".env")
+    with open(dotenv_file, "w") as f:
+        f.write("a=b\nc")
+
+    result = sh.dotenv("run", "printenv", "a")
+
+    assert result == "b\n"
+
+
 def test_run_with_other_env(dotenv_file):
     with open(dotenv_file, "w") as f:
         f.write("a=b")


### PR DESCRIPTION
Dotenv run currently crashes when we use a variable without value (ie with None as value).
Exemple of problematic dotfile:
```
a=b
c
```
 This PR filter out such variables from the dict that is eventually given to Popen, avoiding the crash.