### PR TITLE
Remove warning when last line is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix escaping of quoted values written by `set_key` (#236 by [@bbc2]).
 - Fix `dotenv run` crashing on environment variables without values (#237 by [@yannham]).
+- Remove warning when last line is empty (#238 by [@bbc2]).
 
 ## [0.11.0] - 2020-02-07
 

--- a/src/dotenv/parser.py
+++ b/src/dotenv/parser.py
@@ -197,6 +197,13 @@ def parse_binding(reader):
     reader.set_mark()
     try:
         reader.read_regex(_multiline_whitespace)
+        if not reader.has_next():
+            return Binding(
+                key=None,
+                value=None,
+                original=reader.get_marked(),
+                error=False,
+            )
         reader.read_regex(_export)
         key = parse_key(reader)
         reader.read_regex(_whitespace)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,63 +30,32 @@ def test_set_key_no_file(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "key,value,expected,content",
+    "before,key,value,expected,after",
     [
-        ("a", "", (True, "a", ""), 'a=""\n'),
-        ("a", "b", (True, "a", "b"), 'a="b"\n'),
-        ("a", "'b'", (True, "a", "b"), 'a="b"\n'),
-        ("a", "\"b\"", (True, "a", "b"), 'a="b"\n'),
-        ("a", "b'c", (True, "a", "b'c"), 'a="b\'c"\n'),
-        ("a", "b\"c", (True, "a", "b\"c"), 'a="b\\\"c"\n'),
+        ("", "a", "", (True, "a", ""), 'a=""\n'),
+        ("", "a", "b", (True, "a", "b"), 'a="b"\n'),
+        ("", "a", "'b'", (True, "a", "b"), 'a="b"\n'),
+        ("", "a", "\"b\"", (True, "a", "b"), 'a="b"\n'),
+        ("", "a", "b'c", (True, "a", "b'c"), 'a="b\'c"\n'),
+        ("", "a", "b\"c", (True, "a", "b\"c"), 'a="b\\\"c"\n'),
+        ("a=b", "a", "c", (True, "a", "c"), 'a="c"\n'),
+        ("a=b\n", "a", "c", (True, "a", "c"), 'a="c"\n'),
+        ("a=b\n\n", "a", "c", (True, "a", "c"), 'a="c"\n\n'),
+        ("a=b\nc=d", "a", "e", (True, "a", "e"), 'a="e"\nc=d'),
+        ("a=b\nc=d\ne=f", "c", "g", (True, "c", "g"), 'a=b\nc="g"\ne=f'),
+        ("a=b\n", "c", "d", (True, "c", "d"), 'a=b\nc="d"\n'),
     ],
 )
-def test_set_key_new(dotenv_file, key, value, expected, content):
+def test_set_key(dotenv_file, before, key, value, expected, after):
     logger = logging.getLogger("dotenv.main")
+    with open(dotenv_file, "w") as f:
+        f.write(before)
 
     with mock.patch.object(logger, "warning") as mock_warning:
         result = dotenv.set_key(dotenv_file, key, value)
 
     assert result == expected
-    assert open(dotenv_file, "r").read() == content
-    mock_warning.assert_not_called()
-
-
-def test_set_key_new_with_other_values(dotenv_file):
-    logger = logging.getLogger("dotenv.main")
-    with open(dotenv_file, "w") as f:
-        f.write("a=b\n")
-
-    with mock.patch.object(logger, "warning") as mock_warning:
-        result = dotenv.set_key(dotenv_file, "foo", "bar")
-
-    assert result == (True, "foo", "bar")
-    assert open(dotenv_file, "r").read() == 'a=b\nfoo="bar"\n'
-    mock_warning.assert_not_called()
-
-
-def test_set_key_existing(dotenv_file):
-    logger = logging.getLogger("dotenv.main")
-    with open(dotenv_file, "w") as f:
-        f.write("foo=bar")
-
-    with mock.patch.object(logger, "warning") as mock_warning:
-        result = dotenv.set_key(dotenv_file, "foo", "baz")
-
-    assert result == (True, "foo", "baz")
-    assert open(dotenv_file, "r").read() == 'foo="baz"\n'
-    mock_warning.assert_not_called()
-
-
-def test_set_key_existing_with_other_values(dotenv_file):
-    logger = logging.getLogger("dotenv.main")
-    with open(dotenv_file, "w") as f:
-        f.write("a=b\nfoo=bar\nc=d")
-
-    with mock.patch.object(logger, "warning") as mock_warning:
-        result = dotenv.set_key(dotenv_file, "foo", "baz")
-
-    assert result == (True, "foo", "baz")
-    assert open(dotenv_file, "r").read() == 'a=b\nfoo="baz"\nc=d'
+    assert open(dotenv_file, "r").read() == after
     mock_warning.assert_not_called()
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -87,6 +87,19 @@ from dotenv.parser import Binding, Original, parse_stream
         ]
     ),
     (
+        u"\n\n",
+        [
+            Binding(key=None, value=None, original=Original(string=u"\n\n", line=1), error=False),
+        ]
+    ),
+    (
+        u"a=b\n\n",
+        [
+            Binding(key=u"a", value=u"b", original=Original(string=u"a=b\n", line=1), error=False),
+            Binding(key=None, value=None, original=Original(string=u"\n", line=2), error=False),
+        ]
+    ),
+    (
         u'a=b\n\nc=d',
         [
             Binding(key=u"a", value=u"b", original=Original(string=u"a=b\n", line=1), error=False),


### PR DESCRIPTION
This also simplifies tests and adds test cases for `set_key`.

Closes #235.