### PR TITLE
Pin click==7.0 and mypy==0.761

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bumpversion
 typing; python_version<"3.5"
-click
+click==7.0
 flake8>=2.2.3
 ipython
 mock

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
   pytest
   coverage
   sh
-  click
+  click==7.0
   py{27,py}: ipython<6.0.0
   py34{,-no-typing}: ipython<7.0.0
   py{35,36,37,38,py3}: ipython

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
 skip_install = true
 deps =
   flake8
-  mypy
+  mypy==0.761
 commands =
   flake8 src tests
   mypy --python-version=3.8 src tests


### PR DESCRIPTION
This pins `click==7.0` and `mypy==0.761` since these are the lastest working ones.

This should fix `master`