### PR TITLE
Add support for POSIX default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-*No unreleased change at this time.*
+- Add support for a Bash-like default value in variable expansion (#248 by [@bbc2]).
 
 ## [0.12.0] - 2020-02-28
 

--- a/README.md
+++ b/README.md
@@ -39,18 +39,23 @@ export S3_BUCKET=YOURS3BUCKET
 export SECRET_KEY=YOURSECRETKEYGOESHERE
 ```
 
-`.env` can interpolate variables using POSIX variable expansion,
-variables are replaced from the environment first or from other values
-in the `.env` file if the variable is not present in the environment. 
+Python-dotenv can interpolate variables using POSIX variable expansion.
+
+The value of a variable is the first of the values defined in the following list:
+
+- Value of that variable in the environment.
+- Value of that variable in the `.env` file.
+- Default value, if provided.
+- Empty string.
+
 Ensure that variables are surrounded with `{}` like `${HOME}` as bare 
 variables such as `$HOME` are not expanded.
-(**Note**: Default Value Expansion is not supported as of yet, see
-[\#30](https://github.com/theskumar/python-dotenv/pull/30#issuecomment-244036604).)
 
 ```shell
 CONFIG_PATH=${HOME}/.config/foo
 DOMAIN=example.org
 EMAIL=admin@${DOMAIN}
+DEBUG=${DEBUG:-false}
 ```
 
 ## Getting started

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -304,20 +304,31 @@ def test_dotenv_values_file(dotenv_file):
         ({"b": "c"}, "a=$b", True, {"a": "$b"}),
         ({"b": "c"}, "a=${b}", False, {"a": "${b}"}),
         ({"b": "c"}, "a=${b}", True, {"a": "c"}),
+        ({"b": "c"}, "a=${b:-d}", False, {"a": "${b:-d}"}),
+        ({"b": "c"}, "a=${b:-d}", True, {"a": "c"}),
 
         # Defined in file
         ({}, "b=c\na=${b}", True, {"a": "c", "b": "c"}),
 
         # Undefined
         ({}, "a=${b}", True, {"a": ""}),
+        ({}, "a=${b:-d}", True, {"a": "d"}),
 
         # With quotes
         ({"b": "c"}, 'a="${b}"', True, {"a": "c"}),
         ({"b": "c"}, "a='${b}'", True, {"a": "c"}),
 
+        # With surrounding text
+        ({"b": "c"}, "a=x${b}y", True, {"a": "xcy"}),
+
         # Self-referential
         ({"a": "b"}, "a=${a}", True, {"a": "b"}),
         ({}, "a=${a}", True, {"a": ""}),
+        ({"a": "b"}, "a=${a:-c}", True, {"a": "b"}),
+        ({}, "a=${a:-c}", True, {"a": "c"}),
+
+        # Reused
+        ({"b": "c"}, "a=${b}${b}", True, {"a": "cc"}),
     ],
 )
 def test_dotenv_values_stream(env, string, interpolate, expected):


### PR DESCRIPTION
When interpolation is active, variable expansion can use a default value, like in Bash.