### PR TITLE
fix interpolation order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-*No unreleased change at this time.*
+### Fixed
+
+- Privilege definition in file over the environment in variable expansion (#256 by
+  [@elbehery95]).
 
 ## [0.13.0] - 2020-04-16
 
@@ -197,6 +200,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 [@ulyssessouza]: https://github.com/ulyssessouza
 [@venthur]: https://github.com/venthur
 [@yannham]: https://github.com/yannham
+[@elbehery95]: https://github.com/elbehery95
 
 [Unreleased]: https://github.com/theskumar/python-dotenv/compare/v0.13.0...HEAD
 [0.13.0]: https://github.com/theskumar/python-dotenv/compare/v0.12.0...v0.13.0

--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -214,13 +214,8 @@ def resolve_nested_variables(values):
     # type: (Dict[Text, Optional[Text]]) -> Dict[Text, Optional[Text]]
     def _replacement(name, default):
         # type: (Text, Optional[Text]) -> Text
-        """
-        get appropriate value for a variable name.
-        first search in environ, if not found,
-        then look into the dotenv variables
-        """
         default = default if default is not None else ""
-        ret = os.getenv(name, new_values.get(name, default))
+        ret = new_values.get(name, os.getenv(name, default))
         return ret  # type: ignore
 
     def _re_sub_callback(match):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -334,6 +334,9 @@ def test_dotenv_values_file(dotenv_file):
 
         # Reused
         ({"b": "c"}, "a=${b}${b}", True, {"a": "cc"}),
+
+        # Re-defined and used in file
+        ({"b": "c"}, "b=d\na=${b}", True, {"a": "d", "b": "d"}),
     ],
 )
 def test_dotenv_values_stream(env, string, interpolate, expected):


### PR DESCRIPTION
As per #256 when users refer to an environment variable that is defined at the current environment and re-defined at the file, the interpolation order always favors the os.environ value.

It does not make sense to favor the environment variable as it is already re-defined in the .env file context. This PR reverts the order of getting these values from the proper dicts. Also i have added a test case to expose such behavior