### PR TITLE
Update load_dotenv to return False if no dotenv source is loaded

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -299,7 +299,7 @@ def find_dotenv(filename='.env', raise_error_if_not_found=False, usecwd=False):
 
 
 def load_dotenv(dotenv_path=None, stream=None, verbose=False, override=False, interpolate=True, **kwargs):
-    # type: (Optional[Union[Text, _PathLike, _StringIO]], Optional[_StringIO], bool, bool, bool, Optional[Text]) -> bool
+    # type: (Union[Text, _PathLike, None], Optional[_StringIO], bool, bool, bool, Union[None, Text]) -> bool
     """Parse a .env file and then load all the variables found as environment variables.
 
     - *dotenv_path*: absolute or relative path to .env file.

--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -94,19 +94,20 @@ class DotEnv():
                 if mapping.key is not None:
                     yield mapping.key, mapping.value
 
-    def set_as_environment_variables(self, override=False):
-        # type: (bool) -> bool
+    def set_as_environment_variables(self, override=False, raise_error_if_nothing_set=False):
+        # type: (bool, bool) -> bool
         """
         Set environment variables from a dotenv dict.
         """
-        if self.verbose and not len(self.dict()):
-            logger.info("No variables loaded from %s.", self.dotenv_path)
+        if raise_error_if_nothing_set and not len(self.dict()):
             return False
+
         for k, v in self.dict().items():
             if k in os.environ and not override:
                 continue
             if v is not None:
                 os.environ[to_env(k)] = to_env(v)
+
         return True
 
     def get(self, key):
@@ -300,21 +301,28 @@ def find_dotenv(filename='.env', raise_error_if_not_found=False, usecwd=False):
     return ''
 
 
-def load_dotenv(dotenv_path=None, stream=None, verbose=False, override=False, interpolate=True, **kwargs):
-    # type: (Union[Text, _PathLike, None], Optional[_StringIO], bool, bool, bool, Union[None, Text]) -> bool
+def load_dotenv(dotenv_path=None, stream=None, verbose=False, override=False, interpolate=True,
+                raise_error_if_not_found=False, raise_error_if_nothing_set=False, **kwargs):
+    # type: (Union[Text, _PathLike, None], Optional[_StringIO], bool, bool, bool, bool, bool, Union[None, Text]) -> bool
     """Parse a .env file and then load all the variables found as environment variables.
 
     - *dotenv_path*: absolute or relative path to .env file.
     - *stream*: `StringIO` object with .env content.
-    - *verbose*: whether to output warnings related to missing .env file etc. Defaults to `False`.
-      If `True`, and no environment variables are loaded, raises a `LookupError`.
+    - *verbose*: whether to output log messages related to loading .env files etc. Defaults to `False`.
+    - *raise_error_if_not_found*: whether to output warnings related to missing .env file etc. Defaults to `False`.
+    - *raise_error_if_nothing_set*: whether to raise an error if no environment variables are set. Defaults to `False`.
+      If `True`, and no environment variables are loaded, logs a message and raises a `LookupError`.
     - *override*: where to override the system environment variables with the variables in `.env` file.
       Defaults to `False`.
     """
-    f = dotenv_path or stream or find_dotenv()
-    env = DotEnv(f, verbose=verbose, interpolate=interpolate, **kwargs).set_as_environment_variables(override=override)
-    if verbose and not env:
-        raise LookupError("No variables loaded")
+    f = dotenv_path or stream or find_dotenv(raise_error_if_not_found=raise_error_if_not_found)
+    env = DotEnv(f, verbose=verbose, interpolate=interpolate, **kwargs).set_as_environment_variables(
+                 override=override, raise_error_if_nothing_set=raise_error_if_nothing_set)
+    if raise_error_if_nothing_set and not env:
+        msg = ("No variables set from %s.", f)
+        if verbose:
+            logger.info(msg)
+        raise LookupError(msg)
     return env
 
 

--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -308,7 +308,7 @@ def load_dotenv(dotenv_path=None, stream=None, verbose=False, override=False, in
     - *override*: where to override the system environment variables with the variables in `.env` file.
                   Defaults to `False`.
     """
-    f = dotenv_path if dotenv_path and find_dotenv(filename=str(dotenv_path)) else stream if stream else find_dotenv()
+    f = find_dotenv(filename=str(dotenv_path)) or stream or find_dotenv()
     env = DotEnv(f, verbose=verbose, interpolate=interpolate, **kwargs).set_as_environment_variables(override=override)
     return env if f else False
 

--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -299,7 +299,7 @@ def find_dotenv(filename='.env', raise_error_if_not_found=False, usecwd=False):
 
 
 def load_dotenv(dotenv_path=None, stream=None, verbose=False, override=False, interpolate=True, **kwargs):
-    # type: (Union[Text, _PathLike, None], Optional[_StringIO], bool, bool, bool, Union[None, Text]) -> bool
+    # type: (Optional[Union[Text, _PathLike, _StringIO]], Optional[_StringIO], bool, bool, bool, Optional[Text]) -> bool
     """Parse a .env file and then load all the variables found as environment variables.
 
     - *dotenv_path*: absolute or relative path to .env file.

--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -94,14 +94,11 @@ class DotEnv():
                 if mapping.key is not None:
                     yield mapping.key, mapping.value
 
-    def set_as_environment_variables(self, override=False, raise_error_if_nothing_set=False):
-        # type: (bool, bool) -> bool
+    def set_as_environment_variables(self, override=False):
+        # type: (bool) -> bool
         """
         Set environment variables from a dotenv dict.
         """
-        if raise_error_if_nothing_set and not len(self.dict()):
-            return False
-
         for k, v in self.dict().items():
             if k in os.environ and not override:
                 continue
@@ -301,29 +298,19 @@ def find_dotenv(filename='.env', raise_error_if_not_found=False, usecwd=False):
     return ''
 
 
-def load_dotenv(dotenv_path=None, stream=None, verbose=False, override=False, interpolate=True,
-                raise_error_if_not_found=False, raise_error_if_nothing_set=False, **kwargs):
-    # type: (Union[Text, _PathLike, None], Optional[_StringIO], bool, bool, bool, bool, bool, Union[None, Text]) -> bool
+def load_dotenv(dotenv_path=None, stream=None, verbose=False, override=False, interpolate=True, **kwargs):
+    # type: (Union[Text, _PathLike, None], Optional[_StringIO], bool, bool, bool, Union[None, Text]) -> bool
     """Parse a .env file and then load all the variables found as environment variables.
 
     - *dotenv_path*: absolute or relative path to .env file.
     - *stream*: `StringIO` object with .env content.
     - *verbose*: whether to output log messages related to loading .env files etc. Defaults to `False`.
-    - *raise_error_if_not_found*: whether to output warnings related to missing .env file etc. Defaults to `False`.
-    - *raise_error_if_nothing_set*: whether to raise an error if no environment variables are set. Defaults to `False`.
-      If `True`, and no environment variables are loaded, logs a message and raises a `LookupError`.
     - *override*: where to override the system environment variables with the variables in `.env` file.
-      Defaults to `False`.
+                  Defaults to `False`.
     """
-    f = dotenv_path or stream or find_dotenv(raise_error_if_not_found=raise_error_if_not_found)
-    env = DotEnv(f, verbose=verbose, interpolate=interpolate, **kwargs).set_as_environment_variables(
-                 override=override, raise_error_if_nothing_set=raise_error_if_nothing_set)
-    if raise_error_if_nothing_set and not env:
-        msg = ("No variables set from %s.", f)
-        if verbose:
-            logger.info(msg)
-        raise LookupError(msg)
-    return env
+    f = dotenv_path if dotenv_path and find_dotenv(filename=str(dotenv_path)) else stream if stream else find_dotenv()
+    env = DotEnv(f, verbose=verbose, interpolate=interpolate, **kwargs).set_as_environment_variables(override=override)
+    return env if f else False
 
 
 def dotenv_values(dotenv_path=None, stream=None, verbose=False, interpolate=True, **kwargs):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -235,8 +235,9 @@ def test_load_dotenv_existing_file_empty(dotenv_file):
     logger = logging.getLogger("dotenv.main")
 
     with mock.patch.object(logger, "info") as mock_info:
-        assert dotenv.load_dotenv(dotenv_file) is True
+        result = dotenv.load_dotenv(dotenv_file)
 
+    assert result is True
     mock_info.assert_not_called()
 
 
@@ -244,8 +245,9 @@ def test_load_dotenv_no_file_verbose():
     logger = logging.getLogger("dotenv.main")
 
     with mock.patch.object(logger, "info") as mock_info:
-        assert dotenv.load_dotenv(".does_not_exist", verbose=True) is False
+        result = dotenv.load_dotenv(".does_not_exist", verbose=True)
 
+    assert result is False
     mock_info.assert_called_once_with("Python-dotenv could not find configuration file %s.", ".env")
 
 
@@ -253,9 +255,9 @@ def test_load_dotenv_no_file():
     logger = logging.getLogger("dotenv.main")
 
     with mock.patch.object(logger, "info") as mock_info:
-        assert dotenv.load_dotenv() is False
-        assert dotenv.load_dotenv(".does_not_exist") is False
+        result = dotenv.load_dotenv()
 
+    assert result is False
     mock_info.assert_not_called()
 
 
@@ -283,7 +285,9 @@ def test_load_dotenv_existing_variable_override(dotenv_file):
 
 @mock.patch.dict(os.environ, {}, clear=True)
 def test_load_dotenv_stream_without_string():
-    assert dotenv.load_dotenv(stream=StringIO()) is True
+    result = dotenv.load_dotenv(stream=StringIO())
+
+    assert result is True
 
 
 @mock.patch.dict(os.environ, {}, clear=True)


### PR DESCRIPTION
theskumar/python-dotenv#164 was closed, but I still find the behavior of `load_dotenv()` confusing.

The `load_dotenv()` function is supposed to "Parse a .env file and then load all the variables found as environment variables," according to its docstring. However, the function always returns `True`, even if no .env file is found or no environment variables are set, because of `DotEnv.set_as_environment_variables()`.

@theskumar [commented](https://github.com/theskumar/python-dotenv/issues/164#issuecomment-494750043) in theskumar/python-dotenv#164:

> The return value of load_dotenv is undocumented as I was planning to do something useful with it, but could not settle down to one.
>
> I think it make sense to return proper return based on if file was found or not, but if the idea is to just stop execution if no .env is found I think it would make much more sense to just pass it a `fail_silently=False` and have it raise an exception.

Rather than adding `fail_silently=False`, which is very similar to `verbose=True`, I think the easiest way to move forward on this is to update the behavior of `verbose=True`. This PR will improve `load_dotenv(verbose=True)` in the following ways:

- Improve `DotEnv.set_as_environment_variables()` to log a message and return `False` when no variables are loaded and `verbose=True`. It will still return `True` as usual if `verbose=False`. `logger.info()` is used for consistency with theskumar/python-dotenv#245, although I think a warning would be clearer.
- Add `test_load_dotenv_empty_file()` with tests for `verbose=True` and `verbose=False`.
- Update `test_load_dotenv_no_file_verbose()` to handle the new `LookupError` exception.

Flake8, Pytest, and Tox (only tried Python 2.7 and 3.7) are currently passing on my branch.