### PR TITLE
Fix import error on Python 3.5.0 and 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix potentially empty expanded value for duplicate key (#260 by [@bbc]).
+- Fix import error on Python 3.5.0 and 3.5.1 (#267 by [@gongqingkui]).
 
 ## [0.14.0] - 2020-07-03
 
@@ -206,6 +207,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 [@ekohl]: https://github.com/ekohl
 [@elbehery95]: https://github.com/elbehery95
 [@gergelyk]: https://github.com/gergelyk
+[@gongqingkui]: https://github.com/gongqingkui
 [@greyli]: https://github.com/greyli
 [@qnighy]: https://github.com/qnighy
 [@snobu]: https://github.com/snobu

--- a/src/dotenv/parser.py
+++ b/src/dotenv/parser.py
@@ -55,7 +55,7 @@ try:
             ("error", bool),
         ],
     )
-except ImportError:
+except (ImportError, AttributeError):
     from collections import namedtuple
     Original = namedtuple(  # type: ignore
         "Original",


### PR DESCRIPTION
While `typing` was added in 3.5.0, `typing.Text` was only added in
3.5.2, and so causes an `AttributeError`, not an `ImportError`
  exception.

Replaces #262.

Closes #261.