### PR TITLE
Add --export to `set` and make it create env file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add `--export` option to `set` to make it prepend the binding with `export` (#270 by
+  [@jadutter]).
+
+### Changed
+
+- Make `set` command create the `.env` file in the current directory if no `.env` file was
+  found (#270 by [@jadutter]).
+
 ### Fixed
 
 - Fix potentially empty expanded value for duplicate key (#260 by [@bbc]).
@@ -209,6 +219,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 [@gergelyk]: https://github.com/gergelyk
 [@gongqingkui]: https://github.com/gongqingkui
 [@greyli]: https://github.com/greyli
+[@jadutter]: https://github.com/jadutter
 [@qnighy]: https://github.com/qnighy
 [@snobu]: https://github.com/snobu
 [@techalchemy]: https://github.com/techalchemy

--- a/README.md
+++ b/README.md
@@ -186,16 +186,23 @@ Usage: dotenv [OPTIONS] COMMAND [ARGS]...
 Options:
   -f, --file PATH                 Location of the .env file, defaults to .env
                                   file in current working directory.
+
   -q, --quote [always|never|auto]
                                   Whether to quote or not the variable values.
                                   Default mode is always. This does not affect
                                   parsing.
+
+  -e, --export BOOLEAN
+                                  Whether to write the dot file as an
+                                  executable bash script.
+
+  --version                       Show the version and exit.
   --help                          Show this message and exit.
 
 Commands:
-  get    Retrive the value for the given key.
+  get    Retrieve the value for the given key.
   list   Display all the stored key/value.
-  run    Run command with environment variables from .env file present
+  run    Run command with environment variables present.
   set    Store the given key/value.
   unset  Removes the given key.
 ```

--- a/src/dotenv/cli.py
+++ b/src/dotenv/cli.py
@@ -19,19 +19,23 @@ if IS_TYPE_CHECKING:
 
 @click.group()
 @click.option('-f', '--file', default=os.path.join(os.getcwd(), '.env'),
-              type=click.Path(exists=True),
+              type=click.Path(file_okay=True),
               help="Location of the .env file, defaults to .env file in current working directory.")
 @click.option('-q', '--quote', default='always',
               type=click.Choice(['always', 'never', 'auto']),
               help="Whether to quote or not the variable values. Default mode is always. This does not affect parsing.")
+@click.option('-e', '--export', default=False,
+              type=click.BOOL,
+              help="Whether to write the dot file as an executable bash script.")
 @click.version_option(version=__version__)
 @click.pass_context
-def cli(ctx, file, quote):
-    # type: (click.Context, Any, Any) -> None
+def cli(ctx, file, quote, export):
+    # type: (click.Context, Any, Any, Any) -> None
     '''This script is used to set, get or unset values from a .env file.'''
     ctx.obj = {}
-    ctx.obj['FILE'] = file
     ctx.obj['QUOTE'] = quote
+    ctx.obj['EXPORT'] = export
+    ctx.obj['FILE'] = file
 
 
 @cli.command()
@@ -40,6 +44,11 @@ def list(ctx):
     # type: (click.Context) -> None
     '''Display all the stored key/value.'''
     file = ctx.obj['FILE']
+    if not os.path.isfile(file):
+        raise click.BadParameter(
+            'Path "%s" does not exist.' % (file),
+            ctx=ctx
+        )
     dotenv_as_dict = dotenv_values(file)
     for k, v in dotenv_as_dict.items():
         click.echo('%s=%s' % (k, v))
@@ -54,7 +63,8 @@ def set(ctx, key, value):
     '''Store the given key/value.'''
     file = ctx.obj['FILE']
     quote = ctx.obj['QUOTE']
-    success, key, value = set_key(file, key, value, quote)
+    export = ctx.obj['EXPORT']
+    success, key, value = set_key(file, key, value, quote, export)
     if success:
         click.echo('%s=%s' % (key, value))
     else:
@@ -68,6 +78,11 @@ def get(ctx, key):
     # type: (click.Context, Any) -> None
     '''Retrieve the value for the given key.'''
     file = ctx.obj['FILE']
+    if not os.path.isfile(file):
+        raise click.BadParameter(
+            'Path "%s" does not exist.' % (file),
+            ctx=ctx
+        )
     stored_value = get_key(file, key)
     if stored_value:
         click.echo('%s=%s' % (key, stored_value))
@@ -97,6 +112,11 @@ def run(ctx, commandline):
     # type: (click.Context, List[str]) -> None
     """Run command with environment variables present."""
     file = ctx.obj['FILE']
+    if not os.path.isfile(file):
+        raise click.BadParameter(
+            'Invalid value for \'-f\' "%s" does not exist.' % (file),
+            ctx=ctx
+        )
     dotenv_as_dict = {to_env(k): to_env(v) for (k, v) in dotenv_values(file).items() if v is not None}
 
     if not commandline:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,15 +18,11 @@ def test_set_key_no_file(tmp_path):
     nx_file = str(tmp_path / "nx")
     logger = logging.getLogger("dotenv.main")
 
-    with mock.patch.object(logger, "warning") as mock_warning:
+    with mock.patch.object(logger, "warning"):
         result = dotenv.set_key(nx_file, "foo", "bar")
 
-    assert result == (None, "foo", "bar")
-    assert not os.path.exists(nx_file)
-    mock_warning.assert_called_once_with(
-        "Can't write to %s - it doesn't exist.",
-        nx_file,
-    )
+    assert result == (True, "foo", "bar")
+    assert os.path.exists(nx_file)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Add `--export` option to `set` to make it prepend the binding with
  `export`.
- Make `set` command create the `.env` file in the current directory if
  no `.env` file was found.

Replaces #270.