### PR TITLE
Add boolean conversion operations

### DIFF
--- a/src/dotenv/__init__.py
+++ b/src/dotenv/__init__.py
@@ -1,5 +1,5 @@
 from .compat import IS_TYPE_CHECKING
-from .main import load_dotenv, get_key, set_key, unset_key, find_dotenv, dotenv_values
+from .main import load_dotenv, get_key, get_bool, get_boolean_key, set_key, unset_key, find_dotenv, dotenv_values
 
 if IS_TYPE_CHECKING:
     from typing import Any, Optional
@@ -40,6 +40,8 @@ __all__ = ['get_cli_string',
            'load_dotenv',
            'dotenv_values',
            'get_key',
+           'get_bool',
+           'get_boolean_key',
            'set_key',
            'unset_key',
            'find_dotenv',

--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -102,7 +102,7 @@ class DotEnv():
         return True
 
     def get(self, key, boolean=False):
-        # type: (Text) -> Optional[Union[Text, bool]]
+        # type: (Text, Optional[bool]) -> Optional[Union[Text, bool]]
         """
         """
         data = self.dict()
@@ -336,10 +336,7 @@ def dotenv_values(dotenv_path=None, stream=None, verbose=False, interpolate=True
 
 def get_bool(key, default=None):
     # type: (Text, Union[Text, bool, None]) -> bool
-    if default:
-        value = os.getenv(key, default)
-    else:
-        value = os.getenv(key)
+    value = os.getenv(key, default)
 
     if isinstance(value, (bool, int)):
         # happens if default was a boolean

--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -102,14 +102,14 @@ class DotEnv():
         return True
 
     def get(self, key, boolean=False):
-        # type: (Text, Optional[bool]) -> Optional[Union[Text, bool]]
+        # type: (Text, Optional[bool]) -> Union[Text, bool, None]
         """
         """
         data = self.dict()
 
         if key in data:
             if boolean:
-                return strtobool(data[key])
+                return strtobool(str(data[key]))
             return data[key]
 
         if self.verbose:
@@ -122,11 +122,11 @@ class DotEnv():
         """
         Wrapper around get with boolean=True
         """
-        return self.get(key, True)
+        return bool(self.get(key, True))
 
 
 def get_key(dotenv_path, key_to_get):
-    # type: (Union[Text, _PathLike], Text) -> Optional[Text]
+    # type: (Union[Text, _PathLike], Text) -> Union[Text, bool, None]
     """
     Gets the value of a given key from the given .env
 
@@ -342,4 +342,4 @@ def get_bool(key, default=None):
         # happens if default was a boolean
         return bool(value)
 
-    return bool(strtobool(value))
+    return bool(strtobool(str(value)))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -153,7 +153,7 @@ def test_get_boolean_key_not_found(dotenv_file):
     with mock.patch.object(logger, "warning") as mock_warning:
         result = dotenv.get_boolean_key(dotenv_file, "foo")
 
-    assert result is None
+    assert not result
     mock_warning.assert_called_once_with("Key %s not found in %s.", "foo", dotenv_file)
 
 


### PR DESCRIPTION
closes #291 

I have seen many comments about the fact that boolean environment variables were annoying to retrieve.

This PR implements basic functions making it easier to retrieve a boolean value from env.
This code does not implement its own process to decide how to convert string to boolean, instead, it uses python's [distutils.util.strtobool](https://docs.python.org/3/distutils/apiref.html#distutils.util.strtobool).

The functions are:
- `Dotenv.get_as_boolean(key)`: behaves as `Dotenv.get(key)` with boolean conversion.
- `get_boolean_key(dotenv_path, key_to_get)`: `get_key(dotenv_path, key_to_get)` with boolean conversion.
- `get_bool(key, default=None)`: retrieves a variable from environ and converts it to a boolean. If there is no `key` variable in the environment, then `default` is returned if it is a boolean or on an integer, else it gets converted to a boolean.

I added 38 tests (through 7 test functions) to ensure that it works.