### PR TITLE
Add --override/--no-override flag to "dotenv run"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-_There are no unreleased changes at this time._
+### Added
+
+- Add `--override`/`--no-override` option to `dotenv run` (#312 by [@zueve] and [@bbc2]).
 
 ## [0.16.0] - 2021-03-27
 
@@ -242,6 +244,7 @@ _There are no unreleased changes at this time._
 [@venthur]: https://github.com/venthur
 [@x-yuri]: https://github.com/x-yuri
 [@yannham]: https://github.com/yannham
+[@zueve]: https://github.com/zueve
 
 [Unreleased]: https://github.com/theskumar/python-dotenv/compare/v0.16.0...HEAD
 [0.16.0]: https://github.com/theskumar/python-dotenv/compare/v0.15.0...v0.16.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,6 +138,34 @@ def test_run(tmp_path):
     assert result == "b\n"
 
 
+def test_run_with_existing_variable(tmp_path):
+    sh.cd(str(tmp_path))
+    dotenv_file = str(tmp_path / ".env")
+    with open(dotenv_file, "w") as f:
+        f.write("a=b")
+
+    result = sh.dotenv("run", "printenv", "a", _env={"LANG": "en_US.UTF-8", "a": "c"})
+
+    assert result == "b\n"
+
+
+def test_run_with_existing_variable_not_overridden(tmp_path):
+    sh.cd(str(tmp_path))
+    dotenv_file = str(tmp_path / ".env")
+    with open(dotenv_file, "w") as f:
+        f.write("a=b")
+
+    result = sh.dotenv(
+        "run",
+        "--no-override",
+        "printenv",
+        "a",
+        _env={"LANG": "en_US.UTF-8", "a": "c"},
+    )
+
+    assert result == "c\n"
+
+
 def test_run_with_none_value(tmp_path):
     sh.cd(str(tmp_path))
     dotenv_file = str(tmp_path / ".env")


### PR DESCRIPTION
This makes it possible to not override previously defined environment variables when running `dotenv run`.  It defaults to `--override` for compatibility with the previous behavior.

Closes #302.