### PR TITLE
Make `dotenv get` only show the value instead of key=value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Make `dotenv get <key>` only show the value, not `key=value` (#313 by [@bbc2]).
+
 ### Added
 
 - Add `--override`/`--no-override` option to `dotenv run` (#312 by [@zueve] and [@bbc2]).

--- a/src/dotenv/cli.py
+++ b/src/dotenv/cli.py
@@ -85,7 +85,7 @@ def get(ctx, key):
         )
     stored_value = get_key(file, key)
     if stored_value:
-        click.echo('%s=%s' % (key, stored_value))
+        click.echo(stored_value)
     else:
         exit(1)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,7 +35,7 @@ def test_get_existing_value(cli, dotenv_file):
 
     result = cli.invoke(dotenv_cli, ['--file', dotenv_file, 'get', 'a'])
 
-    assert (result.exit_code, result.output) == (0, "a=b\n")
+    assert (result.exit_code, result.output) == (0, "b\n")
 
 
 def test_get_non_existent_value(cli, dotenv_file):
@@ -124,7 +124,7 @@ def test_get_default_path(tmp_path):
 
     result = sh.dotenv("get", "a")
 
-    assert result == "a=b\n"
+    assert result == "b\n"
 
 
 def test_run(tmp_path):


### PR DESCRIPTION
The `get` subcommand would return `key=value`, which is impractical to retrieve the value of a key in a script.  Since the `key` is already known by the caller, there is no point in showing it.

This also makes the output consistent with the documentation for the subcommand.

Closes #307.