### PR TITLE
Fix tests for build environment relying on `PYTHONPATH`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed tests for build environments relying on `PYTHONPATH` (#318 by [@befeleme]).
+
 ## [0.17.0] - 2021-04-02
 
 ### Changed
@@ -232,6 +238,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 [@andrewsmith]: https://github.com/andrewsmith
 [@asyncee]: https://github.com/asyncee
 [@bbc2]: https://github.com/bbc2
+[@befeleme]: https://github.com/befeleme
 [@cjauvin]: https://github.com/cjauvin
 [@earlbread]: https://github.com/earlbread
 [@ekohl]: https://github.com/ekohl

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import os
+
 import pytest
 import sh
 
@@ -143,8 +145,10 @@ def test_run_with_existing_variable(tmp_path):
     dotenv_file = str(tmp_path / ".env")
     with open(dotenv_file, "w") as f:
         f.write("a=b")
+    env = dict(os.environ)
+    env.update({"LANG": "en_US.UTF-8", "a": "c"})
 
-    result = sh.dotenv("run", "printenv", "a", _env={"LANG": "en_US.UTF-8", "a": "c"})
+    result = sh.dotenv("run", "printenv", "a", _env=env)
 
     assert result == "b\n"
 
@@ -154,14 +158,10 @@ def test_run_with_existing_variable_not_overridden(tmp_path):
     dotenv_file = str(tmp_path / ".env")
     with open(dotenv_file, "w") as f:
         f.write("a=b")
+    env = dict(os.environ)
+    env.update({"LANG": "en_US.UTF-8", "a": "c"})
 
-    result = sh.dotenv(
-        "run",
-        "--no-override",
-        "printenv",
-        "a",
-        _env={"LANG": "en_US.UTF-8", "a": "c"},
-    )
+    result = sh.dotenv("run", "--no-override", "printenv", "a", _env=env)
 
     assert result == "c\n"
 


### PR DESCRIPTION
Hey,
I want to update dotenv to 0.17.0 in Fedora, but realized the two newly introduced tests started failing in the build process.
This happens because defining `_env` [replaces the existing environment](https://amoffat.github.io/sh/sections/special_arguments.html#env), effectively unsetting many variables (which, in my case, means losing information where to look for the module to import). Instead of creating completely new contents, I propose copying existing environment and adding the tested key-value on the top of it. 
This will not affect the existing test suite but can help other packagers. 