### PR TITLE
Fix CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ python =
     3.6: py36, coverage-report
     3.7: py37, coverage-report
     3.8: py38, coverage-report
-    3.9: py39, mypy, lint, manifest, coverage-report
+    3.9: py39, lint, manifest, coverage-report
     pypy2: pypy, coverage-report
     pypy3: pypy3, coverage-report
 
@@ -27,7 +27,7 @@ commands = coverage run --parallel -m pytest {posargs}
 skip_install = true
 deps =
   flake8
-  mypy
+  mypy<0.900
 commands =
   flake8 src tests
   mypy --python-version=3.9 src tests


### PR DESCRIPTION
Mypy was failing because the new version requires some type packages to
be installed even when `ignore_missing_imports` is set to `true`.