### PR TITLE
Avoid leaving any file after running tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,9 @@ from click.testing import CliRunner
 
 @pytest.fixture
 def cli():
-    yield CliRunner()
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        yield runner
 
 
 @pytest.fixture


### PR DESCRIPTION
This notably prevents the file `.nx_file` from being created and not removed after running tests.  That file could also lead to confusing test failures when changing and testing the code of python-dotenv.