### PR TITLE
Require Python >= 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, pypy2, pypy3]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, pypy3]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Require Python 3.5 or a later version.  Python 2 and 3.4 are no longer supported. (#341
+  by [@bbc2]).
+
 ## [0.18.0] - 2021-06-20
 
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,7 @@ setup(
     package_data={
         'dotenv': ['py.typed'],
     },
-    install_requires=[
-        "typing; python_version<'3.5'",
-    ],
+    python_requires=">=3.5",
     extras_require={
         'cli': ['click>=5.0', ],
     },
@@ -47,8 +45,6 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,13 @@
 [tox]
-envlist = lint,py{27,35,36,37,38,39},pypy,pypy3,manifest,coverage-report
+envlist = lint,py{35,36,37,38,39},pypy3,manifest,coverage-report
 
 [gh-actions]
 python =
-    2.7: py27, coverage-report
     3.5: py35, coverage-report
     3.6: py36, coverage-report
     3.7: py37, coverage-report
     3.8: py38, coverage-report
     3.9: py39, lint, manifest, coverage-report
-    pypy2: pypy, coverage-report
     pypy3: pypy3, coverage-report
 
 [testenv]
@@ -19,7 +17,6 @@ deps =
   coverage
   sh
   click
-  py{27,py}: ipython<6.0.0
   py{35,36,37,38,39,py3}: ipython
 commands = coverage run --parallel -m pytest {posargs}
 
@@ -35,8 +32,6 @@ commands =
   mypy --python-version=3.7 src tests
   mypy --python-version=3.6 src tests
   mypy --python-version=3.5 src tests
-  mypy --python-version=3.4 src tests
-  mypy --python-version=2.7 src tests
 
 [testenv:manifest]
 deps = check-manifest


### PR DESCRIPTION
This is a big change.  It will make it possible to simplify the code, add more features, improve the robustness and lower the barrier to new contributions.

As per [Python's packaging documentation][doc], the `python_requires` keyword argument needs `setuptools >= 24.2.0` (released in 2016) and will only have en effect for `pip >= 9.0.0` (released in 2016 as well).

See #329 for more information.

[doc]: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires