### PR TITLE
Add method to update multiple key/values to .env

### DIFF
--- a/src/dotenv/__init__.py
+++ b/src/dotenv/__init__.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
 from .main import (dotenv_values, find_dotenv, get_key, load_dotenv, set_key,
-                   unset_key)
+                   unset_key, update_dict_to_dotenv)
 
 
 def load_ipython_extension(ipython: Any) -> None:
@@ -46,4 +46,5 @@ __all__ = ['get_cli_string',
            'set_key',
            'unset_key',
            'find_dotenv',
-           'load_ipython_extension']
+           'load_ipython_extension',
+           'update_dict_to_dotenv']

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -383,3 +383,26 @@ def test_dotenv_values_file_stream(dotenv_file):
         result = dotenv.dotenv_values(stream=f)
 
     assert result == {"a": "b"}
+
+
+@pytest.mark.parametrize(
+    "before,env_dict,after",
+    [
+        ("", {"a1": "", "a2": "b", "a3": "'b'", "a4": "\"b\""},
+         "a1=''\na2='b'\na3='\\'b\\''\na4='\"b\"'\n"),
+        ("", {"a1": "b'c", "a2": "b\"c"}, "a1='b\\'c'\na2='b\"c'\n"),
+        ("a=b\nb=c\n", {"b": "cc", "c": "d", "d": "e"},
+         "a=b\nb='cc'\nc='d'\nd='e'\n")
+    ],
+)
+def test_update_dict_to_dotenv(dotenv_file, before, env_dict, after):
+    logger = logging.getLogger("dotenv.main")
+    with open(dotenv_file, "w") as f:
+        f.write(before)
+
+    with mock.patch.object(logger, "warning") as mock_warning:
+        dotenv.update_dict_to_dotenv(dotenv_file, env_dict)
+
+    assert open(dotenv_file, "r").read() == after
+    mock_warning.assert_not_called()
+


### PR DESCRIPTION
`update_dict_to_dotenv` was implemented to support for updating multiple environment variables at once.
This method is necessary because `set_key` can update only one environment variable at once.

Feel free to ask any questions or give your opinion. Thanks.

Following things were changed.
* `update_dict_to_dotenv` was added to `main.py`
* `make_env_line` was extracted from `set_key`
* `test_update_dict_to_dotenv` was added to `test_main.py`
* Update `tests/__init__.py` to import `update_dict_to_dotenv`