### PR TITLE
Add missing trailing newline before adding new entry with `set_key`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- In `set_key`, add missing newline character before new entry if necessary. (#361 by
+  [@bbc2])
+
 ## [0.19.1] - 2021-08-09
 
 ### Added

--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -167,13 +167,17 @@ def set_key(
 
     with rewrite(dotenv_path) as (source, dest):
         replaced = False
+        missing_newline = False
         for mapping in with_warn_for_invalid_lines(parse_stream(source)):
             if mapping.key == key_to_set:
                 dest.write(line_out)
                 replaced = True
             else:
                 dest.write(mapping.original.string)
+                missing_newline = not mapping.original.string.endswith("\n")
         if not replaced:
+            if missing_newline:
+                dest.write("\n")
             dest.write(line_out)
 
     return True, key_to_set, value_to_set

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -37,6 +37,7 @@ def test_set_key_no_file(tmp_path):
         ("a=b\nc=d", "a", "e", (True, "a", "e"), "a='e'\nc=d"),
         ("a=b\nc=d\ne=f", "c", "g", (True, "c", "g"), "a=b\nc='g'\ne=f"),
         ("a=b\n", "c", "d", (True, "c", "d"), "a=b\nc='d'\n"),
+        ("a=b", "c", "d", (True, "c", "d"), "a=b\nc='d'\n"),
     ],
 )
 def test_set_key(dotenv_file, before, key, value, expected, after):


### PR DESCRIPTION
Sometimes, the source file doesn't have a trailing newline.  If we add a new binding in such a case, we need to add a newline before the new binding.

Closes #360.