### PR TITLE
Fix installing entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add `encoding` (`Optional[str]`) parameter to `get_key`, `set_key` and `unset_key`.
   (#379 by [@bbc2])
 
+### Fixed
+
+- Use dict to specify the `entry_points` parameter of `setuptools.setup` (#376 by
+  [@mgorny]).
+
 ## [0.19.2] - 2021-11-11
 
 ### Fixed
@@ -296,6 +301,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 [@gongqingkui]: https://github.com/gongqingkui
 [@greyli]: https://github.com/greyli
 [@jadutter]: https://github.com/jadutter
+[@mgorny]: https://github.com/mgorny
 [@qnighy]: https://github.com/qnighy
 [@snobu]: https://github.com/snobu
 [@techalchemy]: https://github.com/techalchemy

--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,11 @@ setup(
     extras_require={
         'cli': ['click>=5.0', ],
     },
-    entry_points='''
-        [console_scripts]
-        dotenv=dotenv.cli:cli
-    ''',
+    entry_points={
+        "console_scripts": [
+            "dotenv=dotenv.cli:cli",
+        ],
+    },
     license='BSD-3-Clause',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Not sure why or when but the string syntax for entry points does not
seem to work correctly anymore (no scripts are installed).  Use
the explicit list-in-dict syntax instead.