### PR TITLE
Don't mark wheels as universal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Use dict to specify the `entry_points` parameter of `setuptools.setup` (#376 by
   [@mgorny]).
+- Don't build universal wheels (#387 by [@bbc2]).
 
 ## [0.19.2] - 2021-11-11
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,10 +5,6 @@ tag = True
 
 [bumpversion:file:src/dotenv/version.py]
 
-
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max-line-length = 120
 exclude = .tox,.git,docs,venv,.venv


### PR DESCRIPTION
Python 2 is no longer supported and so our wheels should not be marked as universal.

Closes #383.