### PR TITLE
Use `open` instead of `io.open`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,10 @@
-import io
 from setuptools import setup
 
 
 def read_files(files):
     data = []
     for file in files:
-        with io.open(file, encoding='utf-8') as f:
+        with open(file, encoding='utf-8') as f:
             data.append(f.read())
     return "\n".join(data)
 
@@ -13,7 +12,7 @@ def read_files(files):
 long_description = read_files(['README.md', 'CHANGELOG.md'])
 
 meta = {}
-with io.open('./src/dotenv/version.py', encoding='utf-8') as f:
+with open('./src/dotenv/version.py', encoding='utf-8') as f:
     exec(f.read(), meta)
 
 setup(

--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -51,7 +51,7 @@ class DotEnv():
     @contextmanager
     def _get_stream(self) -> Iterator[IO[str]]:
         if self.dotenv_path and os.path.isfile(self.dotenv_path):
-            with io.open(self.dotenv_path, encoding=self.encoding) as stream:
+            with open(self.dotenv_path, encoding=self.encoding) as stream:
                 yield stream
         elif self.stream is not None:
             yield self.stream
@@ -129,10 +129,10 @@ def rewrite(
 ) -> Iterator[Tuple[IO[str], IO[str]]]:
     try:
         if not os.path.isfile(path):
-            with io.open(path, "w+", encoding=encoding) as source:
+            with open(path, "w+", encoding=encoding) as source:
                 source.write("")
         with tempfile.NamedTemporaryFile(mode="w+", delete=False, encoding=encoding) as dest:
-            with io.open(path, encoding=encoding) as source:
+            with open(path, encoding=encoding) as source:
                 yield (source, dest)  # type: ignore
     except BaseException:
         if os.path.isfile(dest.name):


### PR DESCRIPTION
Since python 2 support has been dropped, there is no difference between `io.open` and `open`. And it is recommended to use `open` over `io.open`. Just replacing all the occurrences of `io.open` with `open` in this PR.