### PR TITLE
Use built-in unittest.mock instead of third-party mock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,10 @@ bumpversion
 click
 flake8>=2.2.3
 ipython
-mock
 pytest-cov
 pytest>=3.9
 sh>=1.09
 tox
-types-mock
 wheel
 twine
 portray

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -1,6 +1,5 @@
 import os
-
-import mock
+from unittest import mock
 
 
 @mock.patch.dict(os.environ, {}, clear=True)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,8 +3,8 @@ import logging
 import os
 import sys
 import textwrap
+from unittest import mock
 
-import mock
 import pytest
 import sh
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ python =
 
 [testenv]
 deps =
-  mock
   pytest
   coverage
   sh
@@ -27,7 +26,6 @@ skip_install = true
 deps =
   flake8
   mypy
-  types-mock
 commands =
   flake8 src tests
   mypy --python-version=3.11 src tests


### PR DESCRIPTION
Python 3 has a built-in version of mock available as unittest.mock.
Use it instead of installing the third-party package.