### PR TITLE
Skip test_ipython if IPython is not available

### DIFF
--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -2,6 +2,11 @@ import os
 
 import mock
 
+import pytest
+
+
+pytest.importorskip("IPython")
+
 
 @mock.patch.dict(os.environ, {}, clear=True)
 def test_ipython_existing_variable_no_override(tmp_path):


### PR DESCRIPTION
Packaging IPython for more "exotic" architectures poses a serious
problem to Gentoo developers.  Make it possible to easily run the test
suite without it installed by skipping the few tests requiring it.