### PR TITLE
chore: add GitHub Actions for deploying docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,6 @@ jobs:
 
     - name: Publish Documentation
       run: |
-        pip install -r requirements.txt
+        pip install -r requirements-docs.txt
         pip install -e .
         mkdocs gh-deploy --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,3 +23,9 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         make release
+
+    - name: Publish Documentation
+      run: |
+        pip install -r requirements.txt
+        pip install -e .
+        mkdocs gh-deploy --force

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ or with [tox](https://pypi.org/project/tox/) installed:
 Documentation is published with [mkdocs]():
 
 ```shell
-$ pip install -r requirements.txt
+$ pip install -r requirements-docs.txt
 $ pip install -e .
 $ mkdocs serve
 ```

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,4 +9,5 @@ include .coveragerc
 include .editorconfig
 include Makefile
 include requirements.txt
+include requirements-docs.txt
 include src/dotenv/py.typed

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,5 @@
+mdx_truly_sane_lists~=1.2
+mkdocs-include-markdown-plugin~=3.3.0
+mkdocs-material~=8.2.9
+mkdocstrings[python]~=0.18.1
+mkdocs~=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,6 @@ bumpversion
 click
 flake8>=2.2.3
 ipython
-mdx_truly_sane_lists~=1.2
-mkdocs-include-markdown-plugin~=3.3.0
-mkdocs-material~=8.2.9
-mkdocstrings[python]~=0.18.1
-mkdocs~=1.3.0
 pytest-cov
 pytest>=3.9
 sh>=1.09


### PR DESCRIPTION
Build and deploy docs to gh-pages as part of
tag release.
