### PR TITLE
feat(cli) add --format= option to list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ $ dotenv set EMAIL foo@example.org
 $ dotenv list
 USER=foo
 EMAIL=foo@example.org
+$ dotenv list --format=json
+{
+  "USER": "foo",
+  "EMAIL": "foo@example.org"
+}
 $ dotenv run -- python foo.py
 ```
 

--- a/src/dotenv/cli.py
+++ b/src/dotenv/cli.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shlex
 import sys
 from subprocess import Popen
 from typing import Any, Dict, List
@@ -38,7 +39,7 @@ def cli(ctx: click.Context, file: Any, quote: Any, export: Any) -> None:
 @cli.command()
 @click.pass_context
 @click.option('--format', default='simple',
-              type=click.Choice(['simple', 'json']),
+              type=click.Choice(['simple', 'json', 'shell', 'export']),
               help="The format in which to display the list. Default format is simple, "
                    "which displays name=value without quotes.")
 def list(ctx: click.Context, format: bool) -> None:
@@ -53,8 +54,12 @@ def list(ctx: click.Context, format: bool) -> None:
     if format == 'json':
         print(json.dumps(dotenv_as_dict, indent=2, sort_keys=True))
     else:
-        for k, v in dotenv_as_dict.items():
-            click.echo('%s=%s' % (k, v))
+        prefix = 'export ' if format == 'export' else ''
+        for k in sorted(dotenv_as_dict):
+            v = dotenv_as_dict[k]
+            if format in ('export', 'shell'):
+                v = shlex.quote(v)
+            click.echo('%s%s=%s' % (prefix, k, v))
 
 
 @cli.command()

--- a/src/dotenv/cli.py
+++ b/src/dotenv/cli.py
@@ -57,9 +57,10 @@ def list(ctx: click.Context, format: bool) -> None:
         prefix = 'export ' if format == 'export' else ''
         for k in sorted(dotenv_as_dict):
             v = dotenv_as_dict[k]
-            if format in ('export', 'shell'):
-                v = shlex.quote(v)
-            click.echo('%s%s=%s' % (prefix, k, v))
+            if v is not None:
+                if format in ('export', 'shell'):
+                    v = shlex.quote(v)
+                click.echo('%s%s=%s' % (prefix, k, v))
 
 
 @cli.command()

--- a/src/dotenv/cli.py
+++ b/src/dotenv/cli.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 from subprocess import Popen
@@ -36,7 +37,11 @@ def cli(ctx: click.Context, file: Any, quote: Any, export: Any) -> None:
 
 @cli.command()
 @click.pass_context
-def list(ctx: click.Context) -> None:
+@click.option('--format', default='simple',
+              type=click.Choice(['simple', 'json']),
+              help="The format in which to display the list. Default format is simple, "
+                   "which displays name=value without quotes.")
+def list(ctx: click.Context, format: bool) -> None:
     '''Display all the stored key/value.'''
     file = ctx.obj['FILE']
     if not os.path.isfile(file):
@@ -45,8 +50,11 @@ def list(ctx: click.Context) -> None:
             ctx=ctx
         )
     dotenv_as_dict = dotenv_values(file)
-    for k, v in dotenv_as_dict.items():
-        click.echo('%s=%s' % (k, v))
+    if format == 'json':
+        print(json.dumps(dotenv_as_dict, indent=2, sort_keys=True))
+    else:
+        for k, v in dotenv_as_dict.items():
+            click.echo('%s=%s' % (k, v))
 
 
 @cli.command()

--- a/src/dotenv/cli.py
+++ b/src/dotenv/cli.py
@@ -52,7 +52,7 @@ def list(ctx: click.Context, format: bool) -> None:
         )
     dotenv_as_dict = dotenv_values(file)
     if format == 'json':
-        print(json.dumps(dotenv_as_dict, indent=2, sort_keys=True))
+        click.echo(json.dumps(dotenv_as_dict, indent=2, sort_keys=True))
     else:
         prefix = 'export ' if format == 'export' else ''
         for k in sorted(dotenv_as_dict):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,31 +1,34 @@
-import json
 import os
 
 import pytest
 import sh
-
+from typing import Optional
 import dotenv
 from dotenv.cli import cli as dotenv_cli
 from dotenv.version import __version__
 
 
-def test_list(cli, dotenv_file):
+@pytest.mark.parametrize(
+    "format,content,expected",
+    (
+        (None, "x='a b c'", '''x=a b c\n'''),
+        ("simple", "x='a b c'", '''x=a b c\n'''),
+        ("json", "x='a b c'", '''{\n  "x": "a b c"\n}\n'''),
+        ("shell", "x='a b c'", '''x='a b c'\n'''),
+        ("export", "x='a b c'", '''export x='a b c'\n'''),
+    )
+)
+def test_list(cli, dotenv_file, format: Optional[str], content: str, expected: str):
     with open(dotenv_file, "w") as f:
-        f.write("a=b")
+        f.write(content + '\n')
 
-    result = cli.invoke(dotenv_cli, ['--file', dotenv_file, 'list'])
+    args = ['--file', dotenv_file, 'list']
+    if format is not None:
+        args.extend(['--format', format])
 
-    assert (result.exit_code, result.output) == (0, result.output)
+    result = cli.invoke(dotenv_cli, args)
 
-
-def test_list_json(cli, dotenv_file):
-    with open(dotenv_file, "w") as f:
-        f.write("a=b")
-
-    result = cli.invoke(dotenv_cli, ['--file', dotenv_file, 'list', '--format=json'])
-    assert result.exit_code == 0
-    result_obj = json.loads(result.output)
-    assert (len(result_obj), result_obj['a']) == (1, 'b')
+    assert (result.exit_code, result.output) == (0, expected)
 
 
 def test_list_non_existent_file(cli):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pytest
@@ -15,6 +16,16 @@ def test_list(cli, dotenv_file):
     result = cli.invoke(dotenv_cli, ['--file', dotenv_file, 'list'])
 
     assert (result.exit_code, result.output) == (0, result.output)
+
+
+def test_list_json(cli, dotenv_file):
+    with open(dotenv_file, "w") as f:
+        f.write("a=b")
+
+    result = cli.invoke(dotenv_cli, ['--file', dotenv_file, 'list', '--format=json'])
+    assert result.exit_code == 0
+    result_obj = json.loads(result.output)
+    assert (len(result_obj), result_obj['a']) == (1, 'b')
 
 
 def test_list_non_existent_file(cli):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,8 +13,13 @@ from dotenv.version import __version__
     (
         (None, "x='a b c'", '''x=a b c\n'''),
         ("simple", "x='a b c'", '''x=a b c\n'''),
+        ("simple", """x='"a b c"'""", '''x="a b c"\n'''),
+        ("simple", '''x="'a b c'"''', '''x='a b c'\n'''),
         ("json", "x='a b c'", '''{\n  "x": "a b c"\n}\n'''),
-        ("shell", "x='a b c'", '''x='a b c'\n'''),
+        ("shell", "x='a b c'", "x='a b c'\n"),
+        ("shell", """x='"a b c"'""", '''x='"a b c"'\n'''),
+        ("shell", '''x="'a b c'"''', '''x=''"'"'a b c'"'"''\n'''),
+        ("shell", "x='a\nb\nc'", "x='a\nb\nc'\n"),
         ("export", "x='a b c'", '''export x='a b c'\n'''),
     )
 )


### PR DESCRIPTION
The default is simple, which is backwards compatible.
--format=json will display the list as a json dict

resolves #405