### PR TITLE
Add `parse_it` to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ defined in the following list:
 -   [dump-env](https://github.com/sobolevn/dump-env)
 -   [environs](https://github.com/sloria/environs)
 -   [dynaconf](https://github.com/rochacbruno/dynaconf)
+-   [parse_it](https://github.com/naorlivne/parse_it)
 
 ## Acknowledgements
 


### PR DESCRIPTION
`parse_it` is similar to `dynaconf` but focus more on giving the enduser the ability to use his preferred way to set config, `.env` being one of the choices it's using and makes available to endusers