### PR TITLE
Improve conciseness of cli.py and __init__.py

### DIFF
--- a/src/dotenv/__init__.py
+++ b/src/dotenv/__init__.py
@@ -32,7 +32,7 @@ def get_cli_string(
             command.append(key)
             if value:
                 if ' ' in value:
-                    command.append('"%s"' % value)
+                    command.append(f'"{value}"')
                 else:
                     command.append(value)
 

--- a/src/dotenv/cli.py
+++ b/src/dotenv/cli.py
@@ -29,11 +29,8 @@ from .version import __version__
 @click.version_option(version=__version__)
 @click.pass_context
 def cli(ctx: click.Context, file: Any, quote: Any, export: Any) -> None:
-    '''This script is used to set, get or unset values from a .env file.'''
-    ctx.obj = {}
-    ctx.obj['QUOTE'] = quote
-    ctx.obj['EXPORT'] = export
-    ctx.obj['FILE'] = file
+    """This script is used to set, get or unset values from a .env file."""
+    ctx.obj = {'QUOTE': quote, 'EXPORT': export, 'FILE': file}
 
 
 @cli.command()
@@ -43,11 +40,11 @@ def cli(ctx: click.Context, file: Any, quote: Any, export: Any) -> None:
               help="The format in which to display the list. Default format is simple, "
                    "which displays name=value without quotes.")
 def list(ctx: click.Context, format: bool) -> None:
-    '''Display all the stored key/value.'''
+    """Display all the stored key/value."""
     file = ctx.obj['FILE']
     if not os.path.isfile(file):
         raise click.BadParameter(
-            'Path "%s" does not exist.' % (file),
+            f'Path "{file}" does not exist.',
             ctx=ctx
         )
     dotenv_as_dict = dotenv_values(file)
@@ -60,7 +57,7 @@ def list(ctx: click.Context, format: bool) -> None:
             if v is not None:
                 if format in ('export', 'shell'):
                     v = shlex.quote(v)
-                click.echo('%s%s=%s' % (prefix, k, v))
+                click.echo(f'{prefix}{k}={v}')
 
 
 @cli.command()
@@ -68,13 +65,13 @@ def list(ctx: click.Context, format: bool) -> None:
 @click.argument('key', required=True)
 @click.argument('value', required=True)
 def set(ctx: click.Context, key: Any, value: Any) -> None:
-    '''Store the given key/value.'''
+    """Store the given key/value."""
     file = ctx.obj['FILE']
     quote = ctx.obj['QUOTE']
     export = ctx.obj['EXPORT']
     success, key, value = set_key(file, key, value, quote, export)
     if success:
-        click.echo('%s=%s' % (key, value))
+        click.echo(f'{key}={value}')
     else:
         exit(1)
 
@@ -83,11 +80,11 @@ def set(ctx: click.Context, key: Any, value: Any) -> None:
 @click.pass_context
 @click.argument('key', required=True)
 def get(ctx: click.Context, key: Any) -> None:
-    '''Retrieve the value for the given key.'''
+    """Retrieve the value for the given key."""
     file = ctx.obj['FILE']
     if not os.path.isfile(file):
         raise click.BadParameter(
-            'Path "%s" does not exist.' % (file),
+            f'Path "{file}" does not exist.',
             ctx=ctx
         )
     stored_value = get_key(file, key)
@@ -101,12 +98,12 @@ def get(ctx: click.Context, key: Any) -> None:
 @click.pass_context
 @click.argument('key', required=True)
 def unset(ctx: click.Context, key: Any) -> None:
-    '''Removes the given key.'''
+    """Removes the given key."""
     file = ctx.obj['FILE']
     quote = ctx.obj['QUOTE']
     success, key = unset_key(file, key, quote)
     if success:
-        click.echo("Successfully removed %s" % key)
+        click.echo(f"Successfully removed {key}")
     else:
         exit(1)
 
@@ -124,7 +121,7 @@ def run(ctx: click.Context, override: bool, commandline: List[str]) -> None:
     file = ctx.obj['FILE']
     if not os.path.isfile(file):
         raise click.BadParameter(
-            'Invalid value for \'-f\' "%s" does not exist.' % (file),
+            f'Invalid value for \'-f\' "{file}" does not exist.',
             ctx=ctx
         )
     dotenv_as_dict = {


### PR DESCRIPTION
Use f-strings, make some code more concise and change docstrings to double quotes according to[ PEP257](https://peps.python.org/pep-0257/).