### PR TITLE
Fix IPython test warning about deprecated `magic`

### DIFF
--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -17,8 +17,8 @@ def test_ipython_existing_variable_no_override(tmp_path):
     os.environ["a"] = "c"
 
     ipshell = InteractiveShellEmbed()
-    ipshell.magic("load_ext dotenv")
-    ipshell.magic("dotenv")
+    ipshell.run_line_magic("load_ext", "dotenv")
+    ipshell.run_line_magic("dotenv", "")
 
     assert os.environ == {"a": "c"}
 
@@ -33,8 +33,8 @@ def test_ipython_existing_variable_override(tmp_path):
     os.environ["a"] = "c"
 
     ipshell = InteractiveShellEmbed()
-    ipshell.magic("load_ext dotenv")
-    ipshell.magic("dotenv -o")
+    ipshell.run_line_magic("load_ext", "dotenv")
+    ipshell.run_line_magic("dotenv", "-o")
 
     assert os.environ == {"a": "b"}
 
@@ -48,7 +48,7 @@ def test_ipython_new_variable(tmp_path):
     os.chdir(str(tmp_path))
 
     ipshell = InteractiveShellEmbed()
-    ipshell.magic("load_ext dotenv")
-    ipshell.magic("dotenv")
+    ipshell.run_line_magic("load_ext", "dotenv")
+    ipshell.run_line_magic("dotenv", "")
 
     assert os.environ == {"a": "b"}


### PR DESCRIPTION
IPython would complain about:

    DeprecationWarning: `magic(...)` is deprecated since IPython 0.13 (warning added in 8.1), use run_line_magic(magic_name, parameter_s).