### PR TITLE
Handle situations where the cwd does not exist.

### DIFF
--- a/src/dotenv/cli.py
+++ b/src/dotenv/cli.py
@@ -17,8 +17,22 @@ from .main import dotenv_values, set_key, unset_key
 from .version import __version__
 
 
+def enumerate_env():
+    """
+    Return a path for the ${pwd}/.env file.
+
+    If pwd does not exist, return None.
+    """
+    try:
+        cwd = os.getcwd()
+    except FileNotFoundError:
+        return None
+    path = os.path.join(cwd, '.env')
+    return path
+
+
 @click.group()
-@click.option('-f', '--file', default=os.path.join(os.getcwd(), '.env'),
+@click.option('-f', '--file', default=enumerate_env(),
               type=click.Path(file_okay=True),
               help="Location of the .env file, defaults to .env file in current working directory.")
 @click.option('-q', '--quote', default='always',


### PR DESCRIPTION
This is seen in some situations with dynaconf where the system under test starts from a src code directory that got moved around or deleted during operation.

https://github.com/dynaconf/dynaconf/issues/853

```
$ cat REPRODUCER_DIRECT.sh
#!/bin/bash

rm -rf /tmp/foobar
mkdir -p /tmp/foobar
cd /tmp/foobar
rm -rf /tmp/foobar


echo "PWD:$(pwd)"

dotenv --help
```