### PR TITLE
Add python-decouple as a related project

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ defined in the following list:
 -   [environs](https://github.com/sloria/environs)
 -   [dynaconf](https://github.com/rochacbruno/dynaconf)
 -   [parse_it](https://github.com/naorlivne/parse_it)
+-   [python-decouple](https://github.com/HBNetwork/python-decouple)
 
 ## Acknowledgements
 


### PR DESCRIPTION
I usually use dotenv, but I learned about this alternative from libhunt. It seems to have similar goals. (I'll probably stick with dotenv.)