### PR TITLE
feat: accept None to 'set_key' to write value-less environment variable

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -147,11 +147,11 @@ def rewrite(
 def set_key(
     dotenv_path: StrPath,
     key_to_set: str,
-    value_to_set: str,
+    value_to_set: Optional[str],
     quote_mode: str = "always",
     export: bool = False,
     encoding: Optional[str] = "utf-8",
-) -> Tuple[Optional[bool], str, str]:
+) -> Tuple[Optional[bool], str, Optional[str]]:
     """
     Adds or Updates a key/value to the given .env
 
@@ -161,19 +161,25 @@ def set_key(
     if quote_mode not in ("always", "auto", "never"):
         raise ValueError(f"Unknown quote_mode: {quote_mode}")
 
-    quote = (
-        quote_mode == "always"
-        or (quote_mode == "auto" and not value_to_set.isalnum())
-    )
+    if value_to_set is None:
+        if export:
+            line_out = f'export {key_to_set}\n'
+        else:
+            line_out = f"{key_to_set}\n"
+    else:
+        quote = (
+            quote_mode == "always"
+            or (quote_mode == "auto" and not value_to_set.isalnum())
+        )
 
-    if quote:
-        value_out = "'{}'".format(value_to_set.replace("'", "\\'"))
-    else:
-        value_out = value_to_set
-    if export:
-        line_out = f'export {key_to_set}={value_out}\n'
-    else:
-        line_out = f"{key_to_set}={value_out}\n"
+        if quote:
+            value_out = "'{}'".format(value_to_set.replace("'", "\\'"))
+        else:
+            value_out = value_to_set
+        if export:
+            line_out = f'export {key_to_set}={value_out}\n'
+        else:
+            line_out = f"{key_to_set}={value_out}\n"
 
     with rewrite(dotenv_path, encoding=encoding) as (source, dest):
         replaced = False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,6 +26,7 @@ def test_set_key_no_file(tmp_path):
     "before,key,value,expected,after",
     [
         ("", "a", "", (True, "a", ""), "a=''\n"),
+        ("", "a", None, (True, "a", None), "a\n"),
         ("", "a", "b", (True, "a", "b"), "a='b'\n"),
         ("", "a", "'b'", (True, "a", "'b'"), "a='\\'b\\''\n"),
         ("", "a", "\"b\"", (True, "a", '"b"'), "a='\"b\"'\n"),


### PR DESCRIPTION
Changes the signature of `set_key` in the following ways:

1. `value_to_set`: `str` to `Optional[str]`
2. return: `Tuple[Optional[bool], str, str]` to `Tuple[Optional[bool], str, Optional[str]]`

The purpose of this change is to allow a program to pass in `None` to the `value_to_set` parameter, and therefore write the key to the dotenv file without a value. For example:

```python
set_key(".env", "DEBUG_MODE", None)

load_dotenv()

DEBUG_MODE = os.getenv("APP_ENVIRONMENT", "development")

assert DEBUG_MODE == "development"
```

The resulting `.env` file:

```
APP_ENVIRONMENT
```

The use-case is pretty specific, but I think valuable: I'm writing a Python script to parse a file to find environment variables being used, and then writing those to a gitignored `.env` file, so that running the script creates a `.env` file with stubbed values. By allowing `None`, any defaults defined in the config file will be used. In contrast, if the script wrote empty strings or mock values, the defaults would not be used.

Here's an example for illustration:

```python
APP_ENVIRONMENT = os.getenv("APP_ENVIRONMENT", "development") # Optional
DATABASE_DRIVER = os.getenv("DATABASE_DRIVER", "postgresql+asyncpg") # Optional
DATABASE_USERNAME = os.getenv("DATABASE_USERNAME") # Required
DATABASE_PASSWORD = os.getenv("DATABASE_PASSWORD") # Required
```

Note: This is technically a breaking change 
(the change to the return value of `set_key` is not backward-compatible). If this is a problem, we can instead return empty string in the case where `None` is passed for `value_to_set`.
