### PR TITLE
Use pathlib.Path in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ def cli():
 
 
 @pytest.fixture
-def dotenv_file(tmp_path):
-    file_ = tmp_path / '.env'
-    file_.write_bytes(b'')
-    yield str(file_)
+def dotenv_path(tmp_path):
+    path = tmp_path / '.env'
+    path.write_bytes(b'')
+    yield path

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -13,7 +13,7 @@ def test_ipython_existing_variable_no_override(tmp_path):
 
     dotenv_file = tmp_path / ".env"
     dotenv_file.write_text("a=b\n")
-    os.chdir(str(tmp_path))
+    os.chdir(tmp_path)
     os.environ["a"] = "c"
 
     ipshell = InteractiveShellEmbed()
@@ -29,7 +29,7 @@ def test_ipython_existing_variable_override(tmp_path):
 
     dotenv_file = tmp_path / ".env"
     dotenv_file.write_text("a=b\n")
-    os.chdir(str(tmp_path))
+    os.chdir(tmp_path)
     os.environ["a"] = "c"
 
     ipshell = InteractiveShellEmbed()
@@ -45,7 +45,7 @@ def test_ipython_new_variable(tmp_path):
 
     dotenv_file = tmp_path / ".env"
     dotenv_file.write_text("a=b\n")
-    os.chdir(str(tmp_path))
+    os.chdir(tmp_path)
 
     ipshell = InteractiveShellEmbed()
     ipshell.run_line_magic("load_ext", "dotenv")


### PR DESCRIPTION
Replace all filesystem code with `pathlib.Path` objects and operations. Nothing is changed in the source code (and thus in the usage of the lib), only the tests have less boilerplate.

Usually all `*_file` string objects are replaced with `*_path` Path objects. 