### PR TITLE
Fix verbose .env file missing

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -58,7 +58,7 @@ class DotEnv:
             yield self.stream
         else:
             if self.verbose:
-                logger.info(
+                logger.warning(
                     "Python-dotenv could not find configuration file %s.",
                     self.dotenv_path or '.env',
                 )


### PR DESCRIPTION
Changed:
- `logger.info()` -> `logger.warning()` to output a warning as it should if the .env file is missing.