### PR TITLE
Fix set_key creates orphan .env file

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -166,6 +166,10 @@ def set_key(
         or (quote_mode == "auto" and not value_to_set.isalnum())
     )
 
+    if not os.path.exists(dotenv_path):
+        logger.warning("Can't set key to %s - it doesn't exist.", dotenv_path)
+        return None, key_to_set, value_to_set
+
     if quote:
         value_out = "'{}'".format(value_to_set.replace("'", "\\'"))
     else:


### PR DESCRIPTION
Changed:
- `set_key` now checks if the `dotenv_path` exists

Fix https://github.com/theskumar/python-dotenv/issues/480