### PR TITLE
Adds cattrs-env to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ defined in the following list:
 -   [dynaconf](https://github.com/rochacbruno/dynaconf)
 -   [parse_it](https://github.com/naorlivne/parse_it)
 -   [python-decouple](https://github.com/HBNetwork/python-decouple)
+-   [cattrs-env](https://github.com/henryivesjones/cattrs-env)
 
 ## Acknowledgements
 


### PR DESCRIPTION
cattrs-env is a `cattrs` based environment variable parser/validator which can be used in conjunction with `python-dotenv`.