### PR TITLE
Allow modules using load_dotenv to be reloaded when launched in a separate thread

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -280,7 +280,10 @@ def find_dotenv(
 
     def _is_interactive():
         """ Decide whether this is running in a REPL or IPython notebook """
-        main = __import__('__main__', None, None, fromlist=['__file__'])
+        try:
+            main = __import__('__main__', None, None, fromlist=['__file__'])
+        except ModuleNotFoundError:
+            return False
         return not hasattr(main, '__file__')
 
     if usecwd or _is_interactive() or getattr(sys, 'frozen', False):


### PR DESCRIPTION
Hello!

I am one of the maintainers of [gradio](https://github.com/gradio-app/gradio), an os library for developing web applications in python. One of gradio's features is the ability to automatically refresh the web page when the python source code is modified without having to restart the server.

Users started reporting that gradio applications that use `load_dotenv` would fail when reloaded (See https://github.com/gradio-app/gradio/issues/5468). I think the root cause is related to the fact that load_dotenv is being reloaded on a separate thread.

I traced this to the `is_interactive` check and added a fix that works for gradio and I don't think introduces any unintended changes to `python-dotenv`.

Curious to hear your thoughts. Thank you!