### PR TITLE
Add a security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+| Version   | Supported          |
+| --------- | ------------------ |
+| latest    | :white_check_mark: |
+| 0.x       | :x:                |
+
+## Reporting a Vulnerability
+
+If you believe you have identified a security issue with Python-dotenv, please email
+python-dotenv@saurabh-kumar.com. A maintainer will contact you acknowledging the report
+and how to continue.
+
+Be sure to include as much detail as necessary in your report. As with reporting normal
+issues, a minimal reproducible example will help the maintainers address the issue faster.
+If you are able, you may also include a fix for the issue generated with `git
+format-patch`.


### PR DESCRIPTION
This is a basic security policy, mostly to provide an email address. I took inspiration from the example provided by GitHub and the policy from the Pallets project.