### PR TITLE
Enhance dotenv run: Switch to execvpe for better resource management and signal handling

### DIFF
--- a/src/dotenv/cli.py
+++ b/src/dotenv/cli.py
@@ -3,7 +3,6 @@ import os
 import shlex
 import sys
 from contextlib import contextmanager
-from subprocess import Popen
 from typing import Any, Dict, IO, Iterator, List
 
 try:
@@ -161,14 +160,13 @@ def run(ctx: click.Context, override: bool, commandline: List[str]) -> None:
     if not commandline:
         click.echo('No command given.')
         exit(1)
-    ret = run_command(commandline, dotenv_as_dict)
-    exit(ret)
+    run_command(commandline, dotenv_as_dict)
 
 
-def run_command(command: List[str], env: Dict[str, str]) -> int:
-    """Run command in sub process.
+def run_command(command: List[str], env: Dict[str, str]) -> None:
+    """Replace the current process with the specified command.
 
-    Runs the command in a sub process with the variables from `env`
+    Replaces the current process with the specified command and the variables from `env`
     added in the current environment variables.
 
     Parameters
@@ -180,8 +178,8 @@ def run_command(command: List[str], env: Dict[str, str]) -> int:
 
     Returns
     -------
-    int
-        The return code of the command
+    None
+        This function does not return any value. It replaces the current process with the new one.
 
     """
     # copy the current environment variables and add the vales from
@@ -189,11 +187,4 @@ def run_command(command: List[str], env: Dict[str, str]) -> int:
     cmd_env = os.environ.copy()
     cmd_env.update(env)
 
-    p = Popen(command,
-              universal_newlines=True,
-              bufsize=0,
-              shell=False,
-              env=cmd_env)
-    _, _ = p.communicate()
-
-    return p.returncode
+    os.execvpe(command[0], args=command, env=cmd_env)


### PR DESCRIPTION
By switching to os.execvpe instead of subprocess.Popen, we can replace the parent dotenv process with the new process specified by the user. This results in only one active process—the program the user intended to run.

Closes #522 