### PR TITLE
add _is_debugger so load_dotenv will work in pdb

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -292,7 +292,10 @@ def find_dotenv(
             return False
         return not hasattr(main, "__file__")
 
-    if usecwd or _is_interactive() or getattr(sys, "frozen", False):
+    def _is_debugger():
+        return sys.gettrace() is not None
+
+    if usecwd or _is_interactive() or _is_debugger() or getattr(sys, "frozen", False):
         # Should work without __file__, e.g. in REPL or IPython notebook.
         path = os.getcwd()
     else:


### PR DESCRIPTION
add below to `find_dotenv`, so that when user run `load_dotenv()` in pdb or other debugger, they can still load the `.env` file in current working directory, otherwise current `frame_filename` will goes to `Lib/bdb.py`

```python
def _is_debugger():
    return sys.gettrace() is not None

if usecwd or _is_interactive() or _is_debugger() or getattr(sys, "frozen", False):
    ...
```