### PR TITLE
Fix: Use FileNotFoundError for file not found in main.py

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -317,9 +317,10 @@ def find_dotenv(
             return check_path
 
     if raise_error_if_not_found:
-        raise IOError("File not found")
-
+        raise FileNotFoundError("File not found")
     return ""
+        
+
 
 
 def load_dotenv(


### PR DESCRIPTION
Replaced IOError with FileNotFoundError on line 320 of main.py to use a more specific and appropriate exception for file not found errors.