### PR TITLE
Add function to write header block to .env file

### DIFF
--- a/src/dotenv/__init__.py
+++ b/src/dotenv/__init__.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
-from .main import (dotenv_values, find_dotenv, get_key, load_dotenv, set_key,
-                   unset_key)
+from .main import (dotenv_values, find_dotenv, get_key, load_dotenv, set_header,
+                   set_key, unset_key)
 
 
 def load_ipython_extension(ipython: Any) -> None:
@@ -42,6 +42,7 @@ def get_cli_string(
 __all__ = ['get_cli_string',
            'load_dotenv',
            'dotenv_values',
+           'set_header',
            'get_key',
            'set_key',
            'unset_key',

--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -396,3 +396,36 @@ def dotenv_values(
         override=True,
         encoding=encoding,
     ).dict()
+
+
+def set_header(
+    dotenv_path: StrPath,
+    header: str,
+    encoding: Optional[str] = "utf-8",
+) -> Tuple[bool, Optional[str]]:
+    """
+    Adds or Updates a header in the .env file
+
+    Parameters:
+        dotenv_path: Absolute or relative path to .env file.
+        header: The desired header block
+        encoding: Encoding to be used to read the file.
+    Returns:
+        Bool: True if at least one environment variable is set else False
+        Str: The header that was written
+    """
+    with rewrite(dotenv_path, encoding=encoding) as (source, dest):
+        if not header or not header.strip():
+            logger.info("Ignoring empty header.")
+            return False, header
+
+        header = header.strip()
+        lines = header.split("\n")
+        for i, line in enumerate(lines):
+            if not line.startswith("# "):
+                lines[i] = f"# {line}"
+        header = "\n".join(lines)
+        text = "".join(atom for atom in source.readlines() if not atom.startswith("#"))
+        dest.write(f"{header}\n{text}\n")
+
+    return True, header


### PR DESCRIPTION
## Feature request

Sometimes a user may wish to include a header block in the `.env` file that is produced. For example, to indicate that the file is automatically generated and updates will not persist:

#### Sample .env containing header

```
# This file is automatically generated. Any
# manual changes may be overwritten at any
# time by system XYZ.
a=b
c=d
```

### Proposed Addition

Create a `set_header` method to write a header block out to the target `.env` file

*Usage*

```py
import textwrap
from dotenv import set_header

header = textwrap.dedent(
    """
    # This file is automatically generated. Any
    # manual changes may be overwritten at any
    # time by system XYZ.
    """
)
set_header("~/.env", header)
```