### PR TITLE
skip 000 permission tests for root user

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -61,6 +61,7 @@ def test_set_key_encoding(dotenv_path):
     assert dotenv_path.read_text(encoding=encoding) == "a='é'\n"
 
 
+@pytest.mark.skipif(os.geteuid() == 0, reason="Root user can access files even with 000 permissions.")
 def test_set_key_permission_error(dotenv_path):
     dotenv_path.chmod(0o000)
 
@@ -167,6 +168,7 @@ def test_unset_encoding(dotenv_path):
     assert dotenv_path.read_text(encoding=encoding) == ""
 
 
+@pytest.mark.skipif(os.geteuid() == 0, reason="Root user can access files even with 000 permissions.")
 def test_set_key_unauthorized_file(dotenv_path):
     dotenv_path.chmod(0o000)
 


### PR DESCRIPTION
### What
This pull request modifies the unit tests to skip two specific tests if the underlying user is "root".

### Why
Two of the unit tests fail (false negatives) if executed as the "root" user on Linux. This change is necessary because the tests involve changing file permissions to `000` and verifying if the user can access the file. Since the root user has unrestricted access to the entire file system, these tests are not applicable to the root user.

### Details
- **Tests Affected**:
  1. `test_set_key_permission_error()`
  2. `test_set_key_unauthorized_file()`

- **Implementation**: The tests now include a condition to check if the underlying user is "root". If the user is root, the tests are skipped using the `pytest.skip` function.

### Impact
- **Positive**: Ensures that the test suite runs correctly and avoids false negatives when executed by the root user.
- **Negative**: None identified.

### Testing
- The changes have been tested in both root and non-root environments to verify that the tests are skipped for the root user and executed correctly for non-root users.
