### PR TITLE
ocs: clarify what load_dotenv() does in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,19 @@ configurable via the environment:
 ```python
 from dotenv import load_dotenv
 
-load_dotenv()  # take environment variables
+load_dotenv()  # reads variables from a .env file and sets them in os.environ
+```
+
 
 # Code of your application, which uses environment variables (e.g. from `os.environ` or
 # `os.getenv`) as if they came from the actual environment.
-```
 
-By default, `load_dotenv` doesn't override existing environment variables and looks for a `.env` file in same directory as python script or searches for it incrementally higher up.
+
+By default, `load_dotenv()` will:
+
+- Look for a `.env` file in the same directory as the Python script (or higher up the directory tree).
+- Read each key-value pair and add it to `os.environ`.
+- **Not override** an environment variable that is already set, unless you explicitly pass `override=True`.
 
 To configure the development environment, add a `.env` in the root directory of your
 project:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ load_dotenv()  # reads variables from a .env file and sets them in os.environ
 
 By default, `load_dotenv()` will:
 
+
 - Look for a `.env` file in the same directory as the Python script (or higher up the directory tree).
 - Read each key-value pair and add it to `os.environ`.
 - **Not override** an environment variable that is already set, unless you explicitly pass `override=True`.


### PR DESCRIPTION
This PR updates the README to explicitly describe what `load_dotenv()` does.

- Makes it clear that `load_dotenv()` reads key-value pairs from a `.env` file and sets them in `os.environ`.
- States that existing environment variables are **not overridden** unless `override=True` is passed.
- Removes redundant wording for clarity.

This addresses the documentation gap highlighted in issue #571.  

Fixes #571
