### PR TITLE
ci: enable testing on Python 3.14t (free-threaded)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - ubuntu-latest
         python-version:
-          ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", pypy3.9, pypy3.10]
+          ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", pypy3.9, pypy3.10]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
ci: enable testing on Python 3.14t (free-threaded) alongside standard 3.14