### PR TITLE
fix: Add missing 3.14 PyPI classifier.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",


### PR DESCRIPTION
3.14 support added in #579 but the corresponding PyPI classifier is missing, resulting in a false negative on https://pyreadiness.org/3.14/