### PR TITLE
Clean up "Related projects" section of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,11 +233,10 @@ defined in the following list:
     Procfile-based applications.
 -   [django-dotenv](https://github.com/jpadilla/django-dotenv)
 -   [django-environ](https://github.com/joke2k/django-environ)
--   [django-environ-2](https://github.com/sergeyklay/django-environ-2)
 -   [django-configuration](https://github.com/jezdez/django-configurations)
 -   [dump-env](https://github.com/sobolevn/dump-env)
 -   [environs](https://github.com/sloria/environs)
--   [dynaconf](https://github.com/rochacbruno/dynaconf)
+-   [dynaconf](https://github.com/dynaconf/dynaconf)
 -   [parse_it](https://github.com/naorlivne/parse_it)
 -   [python-decouple](https://github.com/HBNetwork/python-decouple)
 


### PR DESCRIPTION
Changes:

- Removed django-environ-2: The project was archived on GitHub.
- Changed URL of dynaconf: The canonical repository changed.

Those are very conservative choices. I haven't added projects, or removed projects that seemed less relevant.