### PR TITLE
Docs: Improve readability of reference page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,14 @@ markdown_extensions:
   - mdx_truly_sane_lists
 
 plugins:
-  - mkdocstrings
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            separate_signature: true
+            show_root_heading: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
   - search
 nav:
   - Home: index.md


### PR DESCRIPTION
This uses some (but not all) of the settings recommended at https://mkdocstrings.github.io/python/usage/#recommended-settings.

Changes to the "Reference" page:

- Replace section heading with function name (instead of function declaration): This should be more readable.
    - The function declaration is now shown in a code block instead of the heading.
- Added "Table of contents" to the right, to quickly navigate to a particular method.
- Removed "Source code": It removes clutter from the page and probably wasn't very useful (but it can easily be added back if needed).


Before             |  After
:-------------------------:|:-------------------------:
<img width="2311" height="1795" alt="dotenv_docs_before" src="https://github.com/user-attachments/assets/3a81ca61-26c5-4577-8129-317d34ac43b1" /> | <img width="2311" height="1803" alt="dotenv_docs_after" src="https://github.com/user-attachments/assets/cd954e6d-15f8-4526-a44d-8940908cfa19" />