### PR TITLE
Drop Python 3.9 support and update PyPy to 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - ubuntu-latest
         python-version:
-          ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", pypy3.9, pypy3.10]
+          ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", pypy3.11]
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -37,7 +36,7 @@ classifiers = [
     "Environment :: Web Environment",
 ]
 
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dynamic = ["version", "readme"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
-envlist = lint,py{39,310,311,312,313},pypy3,manifest,coverage-report
+envlist = lint,py{310,311,312,313,314,314t},pypy3,manifest,coverage-report
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
     3.13: py313, lint, manifest
     3.14: py314
-    pypy-3.9: pypy3
+    3.14t: py314t
+    pypy-3.11: pypy3
 
 [testenv]
 deps =
@@ -17,11 +17,11 @@ deps =
     pytest-cov
     sh >= 2.0.2, <3
     click
-    py{39,310,311,312,313,3.14,pypy3}: ipython
+    py{310,311,312,313,314,314t,pypy3}: ipython
 commands = pytest --cov --cov-report=term-missing {posargs}
 depends =
-    py{39,310,311,312,313,314},pypy3: coverage-clean
-    coverage-report: py{39,310,311,312,313,314},pypy3
+    py{310,311,312,313,314,314t},pypy3: coverage-clean
+    coverage-report: py{310,311,312,313,314,314t},pypy3
 
 [testenv:lint]
 skip_install = true
@@ -36,7 +36,7 @@ commands =
     mypy --python-version=3.12 src tests
     mypy --python-version=3.11 src tests
     mypy --python-version=3.10 src tests
-    mypy --python-version=3.9 src tests
+
 
 [testenv:format]
 skip_install = true


### PR DESCRIPTION
Python 3.9 reached end-of-life on October 5, 2025. This commit removes
support for Python 3.9 and updates the minimum required version to
Python 3.10.

Additionally, PyPy has been updated from 3.10 to 3.11, and proper
support for Python 3.14 free-threading builds (3.14t) has been added
with separate tox environments.

Changes:
- Update requires-python from >=3.9 to >=3.10 in pyproject.toml
- Remove Python 3.9 classifier from package metadata
- Remove Python 3.9 and PyPy 3.9 from CI test matrix
- Update PyPy from 3.10 to 3.11 (latest stable version)
- Remove py39 from tox envlist and gh-actions mapping
- Remove mypy type checking for Python 3.9
- Add separate tox environments for py314 and py314t to properly
  support both regular and free-threading Python 3.14 builds
- Update all tox environment references to include py314 and py314t

The project now officially supports:
- CPython: 3.10, 3.11, 3.12, 3.13, 3.14 (including free-threading)
- PyPy: 3.11