### PR TITLE
ci: improve workflow efficiency with best practices

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,19 @@
 name: Run Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
- Limit workflow triggers to main branch only to avoid redundant runs
- Add concurrency control to cancel outdated workflow runs
- Set 15-minute timeout to prevent hung jobs
