### PR TITLE
Remove the use of `sh` in tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ click
 ipython
 pytest-cov
 pytest>=3.9
-sh>=2
 tox
 wheel
 ruff

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,0 +1,46 @@
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+
+def run_dotenv(
+    args: Sequence[str],
+    cwd: str | Path | None = None,
+    env: dict | None = None,
+) -> subprocess.CompletedProcess:
+    """
+    Run the `dotenv` CLI in a subprocess with the given arguments.
+    """
+
+    process = subprocess.run(
+        ["dotenv", *args],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        env=env,
+    )
+
+    return process
+
+
+def check_process(
+    process: subprocess.CompletedProcess,
+    exit_code: int,
+    stdout: str | None = None,
+):
+    """
+    Check that the process completed with the expected exit code and output.
+
+    This provides better error messages than directly checking the attributes.
+    """
+
+    assert process.returncode == exit_code, (
+        f"Unexpected exit code {process.returncode} (expected {exit_code})\n"
+        f"stdout:\n{process.stdout}\n"
+        f"stderr:\n{process.stderr}"
+    )
+
+    if stdout is not None:
+        assert process.stdout == stdout, (
+            f"Unexpected output: {process.stdout.strip()!r} (expected {stdout!r})"
+        )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@ import io
 import logging
 import os
 import stat
+import subprocess
 import sys
 import textwrap
 from unittest import mock
@@ -9,9 +10,6 @@ from unittest import mock
 import pytest
 
 import dotenv
-
-if sys.platform != "win32":
-    import sh
 
 
 def test_set_key_no_file(tmp_path):
@@ -483,7 +481,6 @@ def test_load_dotenv_file_stream(dotenv_path):
     assert os.environ == {"a": "b"}
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="sh module doesn't support Windows")
 def test_load_dotenv_in_current_dir(tmp_path):
     dotenv_path = tmp_path / ".env"
     dotenv_path.write_bytes(b"a=b")
@@ -499,9 +496,14 @@ def test_load_dotenv_in_current_dir(tmp_path):
     )
     os.chdir(tmp_path)
 
-    result = sh.Command(sys.executable)(code_path)
+    result = subprocess.run(
+        [sys.executable, str(code_path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
 
-    assert result == "b\n"
+    assert result.stdout == "b\n"
 
 
 def test_dotenv_values_file(dotenv_path):

--- a/tests/test_zip_imports.py
+++ b/tests/test_zip_imports.py
@@ -1,14 +1,11 @@
 import os
+import posixpath
+import subprocess
 import sys
 import textwrap
 from typing import List
 from unittest import mock
 from zipfile import ZipFile
-
-import pytest
-
-if sys.platform != "win32":
-    import sh
 
 
 def walk_to_root(path: str):
@@ -16,7 +13,7 @@ def walk_to_root(path: str):
     current_dir = path
     while last_dir != current_dir:
         yield current_dir
-        (parent_dir, _) = os.path.split(current_dir)
+        parent_dir = posixpath.dirname(current_dir)
         last_dir, current_dir = current_dir, parent_dir
 
 
@@ -32,12 +29,11 @@ def setup_zipfile(path, files: List[FileToAdd]):
     with ZipFile(zip_file_path, "w") as zipfile:
         for f in files:
             zipfile.writestr(data=f.content, zinfo_or_arcname=f.path)
-            for dirname in walk_to_root(os.path.dirname(f.path)):
+            for dirname in walk_to_root(posixpath.dirname(f.path)):
                 if dirname not in dirs_init_py_added_to:
-                    print(os.path.join(dirname, "__init__.py"))
-                    zipfile.writestr(
-                        data="", zinfo_or_arcname=os.path.join(dirname, "__init__.py")
-                    )
+                    init_path = posixpath.join(dirname, "__init__.py")
+                    print(f"setup_zipfile: {init_path}")
+                    zipfile.writestr(data="", zinfo_or_arcname=init_path)
                     dirs_init_py_added_to.add(dirname)
     return zip_file_path
 
@@ -65,7 +61,6 @@ def test_load_dotenv_gracefully_handles_zip_imports_when_no_env_file(tmp_path):
     import child1.child2.test  # noqa
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="sh module doesn't support Windows")
 def test_load_dotenv_outside_zip_file_when_called_in_zipfile(tmp_path):
     zip_file_path = setup_zipfile(
         tmp_path,
@@ -83,24 +78,32 @@ def test_load_dotenv_outside_zip_file_when_called_in_zipfile(tmp_path):
         ],
     )
     dotenv_path = tmp_path / ".env"
-    dotenv_path.write_bytes(b"a=b")
+    dotenv_path.write_bytes(b"A=x")
     code_path = tmp_path / "code.py"
     code_path.write_text(
         textwrap.dedent(
             f"""
-        import os
-        import sys
+            import os
+            import sys
 
-        sys.path.append("{zip_file_path}")
+            sys.path.append({str(zip_file_path)!r})
 
-        import child1.child2.test
+            import child1.child2.test
 
-        print(os.environ['a'])
-    """
+            print(os.environ['A'])
+            """
         )
     )
-    os.chdir(str(tmp_path))
 
-    result = sh.Command(sys.executable)(code_path)
+    result = subprocess.run(
+        [sys.executable, str(code_path)],
+        capture_output=True,
+        check=True,
+        cwd=tmp_path,
+        text=True,
+        env={
+            k: v for k, v in os.environ.items() if k.upper() != "A"
+        },  # env without 'A'
+    )
 
-    assert result == "b\n"
+    assert result.stdout == "x\n"

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ python =
 deps =
     pytest
     pytest-cov
-    sh >= 2.0.2, <3
     click
     py{310,311,312,313,314,314t,pypy3}: ipython
 commands = pytest --cov --cov-report=term-missing {posargs}


### PR DESCRIPTION
This change has the following benefits:

- Remove `sh` as a development dependency.
- Increase test coverage on Windows.
- Improve the robustness of some tests against leftover `.env` files in the repository.
    - This is not perfect yet: If you have a `.env` file in your repository, it still disrupts some tests (for `find_dotenv`).
- Improve the readability of error messages for some tests.