### PR TITLE
fix: apply expanduser to dotenv_path

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -53,6 +53,10 @@ class DotEnv:
         override: bool = True,
     ) -> None:
         self.dotenv_path: Optional[StrPath] = dotenv_path
+        if isinstance(dotenv_path, str):
+            self.dotenv_path = os.path.expanduser(dotenv_path)
+        elif dotenv_path is not None:
+            self.dotenv_path = pathlib.Path(dotenv_path).expanduser()
         self.stream: Optional[IO[str]] = stream
         self._dict: Optional[Dict[str, Optional[str]]] = None
         self.verbose: bool = verbose
@@ -174,6 +178,10 @@ def set_key(
     If the .env path given doesn't exist, fails instead of risking creating
     an orphan .env somewhere in the filesystem
     """
+    if isinstance(dotenv_path, str):
+        dotenv_path = os.path.expanduser(dotenv_path)
+    else:
+        dotenv_path = pathlib.Path(dotenv_path).expanduser()
     if quote_mode not in ("always", "auto", "never"):
         raise ValueError(f"Unknown quote_mode: {quote_mode}")
 
@@ -220,6 +228,10 @@ def unset_key(
     If the .env path given doesn't exist, fails.
     If the given key doesn't exist in the .env, fails.
     """
+    if isinstance(dotenv_path, str):
+        dotenv_path = os.path.expanduser(dotenv_path)
+    else:
+        dotenv_path = pathlib.Path(dotenv_path).expanduser()
     if not os.path.exists(dotenv_path):
         logger.warning("Can't delete from %s - it doesn't exist.", dotenv_path)
         return None, key_to_unset


### PR DESCRIPTION
## Summary
- Apply `os.path.expanduser()` (for `str` paths) and `Path.expanduser()` (for `Path` objects) to `dotenv_path` so that `~` is properly expanded to the user's home directory
- The fix preserves the original type: `str` inputs remain `str`, `Path` inputs remain `Path`
- Applied in `DotEnv.__init__`, `set_key()`, and `unset_key()` — all places where `dotenv_path` is used directly

Fixes #525

## Test plan
- All 106 existing tests in `test_main.py` pass with no modifications
- Verified that `dotenv_path="~/.env"` correctly expands to the full home directory path
- Verified that `Path("~/.env")` correctly expands via `Path.expanduser()`
- Verified that paths without `~` are unchanged
- Verified that `None` is handled correctly (no expansion attempted)