### PR TITLE
Fix CLI 'get' command treating empty-string values as missing

### DIFF
--- a/src/dotenv/cli.py
+++ b/src/dotenv/cli.py
@@ -136,7 +136,7 @@ def get(ctx: click.Context, key: Any) -> None:
         values = dotenv_values(stream=stream)
 
     stored_value = values.get(key)
-    if stored_value:
+    if stored_value is not None:
         click.echo(stored_value)
     else:
         sys.exit(1)


### PR DESCRIPTION
The `get` CLI command uses a truthiness check (`if stored_value:`) to determine whether a key was found. This fails for empty-string values, since `bool("") is False`.

For example, given a `.env` file with:
```
DATABASE_PREFIX=
EMPTY_VAR=""
```

Running `dotenv get DATABASE_PREFIX` exits with code 1, as if the key doesn't exist — but it does exist, it's just set to an empty string.

The fix changes the check from `if stored_value:` to `if stored_value is not None:`, which correctly distinguishes between a key with an empty value and a key that is genuinely absent.
