### PR TITLE
Fix _rest_of_line regex alternation order for \r\n line endings

### DIFF
--- a/src/dotenv/parser.py
+++ b/src/dotenv/parser.py
@@ -27,7 +27,7 @@ _double_quoted_value = make_regex(r'"((?:\\"|[^"])*)"')
 _unquoted_value = make_regex(r"([^\r\n]*)")
 _comment = make_regex(r"(?:[^\S\r\n]*#[^\r\n]*)?")
 _end_of_line = make_regex(r"[^\S\r\n]*(?:\r\n|\n|\r|$)")
-_rest_of_line = make_regex(r"[^\r\n]*(?:\r|\n|\r\n)?")
+_rest_of_line = make_regex(r"[^\r\n]*(?:\r\n|\r|\n)?")
 _double_quote_escapes = make_regex(r"\\[\\'\"abfnrtv]")
 _single_quote_escapes = make_regex(r"\\[\\']")
 


### PR DESCRIPTION
The `_rest_of_line` regex uses the alternation `\r|\n|\r\n` to match line endings. Since regex engines try alternations left-to-right, `\r` is matched before `\r\n` ever gets a chance. On Windows-style `\r\n` endings, this means only the `\r` is consumed and the `\n` is left unconsumed for the next parse step.

The other line-ending regexes in the same file already use the correct order:

| Regex | Pattern | Correct? |
|---|---|---|
| `_newline` | `\r\n\|\n\|\r` | ✓ |
| `_end_of_line` | `\r\n\|\n\|\r` | ✓ |
| `_rest_of_line` | `\r\|\n\|\r\n` | ✗ |

This `_rest_of_line` regex is used in the error-recovery path of `parse_binding` (line 170), so the impact shows up when parsing malformed lines in `.env` files with Windows line endings — the unconsumed `\n` bleeds into the next entry.

The fix simply reorders the alternation to `\r\n|\r|\n` to match the longest option first, consistent with the other regexes.
