### PR TITLE
fix: treat inline comment as empty value when key= is followed by # comment

### DIFF
--- a/src/dotenv/parser.py
+++ b/src/dotenv/parser.py
@@ -133,7 +133,7 @@ def parse_value(reader: Reader) -> str:
     elif char == '"':
         (value,) = reader.read_regex(_double_quoted_value)
         return decode_escapes(_double_quote_escapes, value)
-    elif char in ("", "\n", "\r"):
+    elif char in ("", "\n", "\r", "#"):
         return ""
     else:
         return parse_unquoted_value(reader)


### PR DESCRIPTION
## Summary

Fix inline comment being included as the value when a key has an empty value.

## Problem

```
WITH_VALUE=hello # comment   ->  'hello'    ✓ correct
EMPTY_VALUE= # comment       ->  '# comment' ✗ wrong (should be '')
JUST_EMPTY=                  ->  ''           ✓ correct
```

## Root cause

In `parse_value()`, after the `=` sign and trailing whitespace are consumed by `_equal_sign`, the next character is checked:

```python
elif char in ('', '\n', '\r'):
    return ''
```

When the value is `KEY= # comment`, after `= ` is consumed, the next char is `#`. Since `#` isn't in the check, it falls through to `parse_unquoted_value()`, which captures `# comment` as the value. The regex `\s+#.*` in `parse_unquoted_value` can't strip it because the `#` is at the start — there's no whitespace before it.

## Fix

```diff
-    elif char in ('', '\n', '\r'):
+    elif char in ('', '\n', '\r', '#'):
         return ''
```

Adding `#` to the empty-value check ensures that when the value position starts with `#`, it's recognized as an inline comment and the value is returned as empty. The comment itself is then properly consumed by `reader.read_regex(_comment)` in `parse_binding()`.

Fixes #600