### PR TITLE
fix: incorrect uv commands in CONTRIBUTING.md and .gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,4 +126,7 @@ dmypy.json
 ### Python Patch ###
 .venv/
 
+# uv
+uv.lock
+
 # End of https://www.gitignore.io/api/python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ Executing the tests:
     $ uv venv
     $ uv pip install -r requirements.txt
     $ uv pip install -e .
-    $ uv ruff check .
-    $ uv format .
+    $ uv run ruff check .
+    $ uv run ruff format .
     $ uv run pytest
 
 or with [tox](https://pypi.org/project/tox/) installed:
@@ -21,7 +21,7 @@ or with [tox](https://pypi.org/project/tox/) installed:
 
 Use of pre-commit is recommended:
 
-    $ uv run precommit install
+    $ uv run pre-commit install
 
 
 Documentation is published with [mkdocs]():


### PR DESCRIPTION
While setting up the project locally, I found some incorrect information in `CONTRIBUTING.md`. 

- `uv ruff check .` -> `uv run ruff check .`
- `uv format .` -> `uv run ruff format .`
- `uv run precommit install` -> `uv run pre-commit install`

After getting these commands to work, a `uv.lock` file was auto-generated by `uv run`. Since this shouldn't be tracked, I added it to `.gitignore`.
