### PR TITLE
fix(parser): support bash-style single-quote splices in values

### DIFF
--- a/src/dotenv/parser.py
+++ b/src/dotenv/parser.py
@@ -23,6 +23,7 @@ _single_quoted_key = make_regex(r"'([^']+)'")
 _unquoted_key = make_regex(r"([^=\#\s]+)")
 _equal_sign = make_regex(r"(=[^\S\r\n]*)")
 _single_quoted_value = make_regex(r"'((?:\\'|[^'])*)'")
+_single_quote_splice = make_regex('"\'"')
 _double_quoted_value = make_regex(r'"((?:\\"|[^"])*)"')
 _unquoted_value = make_regex(r"([^\r\n]*)")
 _comment = make_regex(r"(?:[^\S\r\n]*#[^\r\n]*)?")
@@ -125,11 +126,23 @@ def parse_unquoted_value(reader: Reader) -> str:
     return re.sub(r"\s+#.*", "", part).rstrip()
 
 
+def parse_single_quoted_value(reader: Reader) -> str:
+    splice_value = '"\'"'
+    value = ""
+    while True:
+        (part,) = reader.read_regex(_single_quoted_value)
+        value += decode_escapes(_single_quote_escapes, part)
+        if reader.peek(len(splice_value)) != splice_value:
+            break
+        reader.read_regex(_single_quote_splice)
+        value += "'"
+    return value
+
+
 def parse_value(reader: Reader) -> str:
     char = reader.peek(1)
     if char == "'":
-        (value,) = reader.read_regex(_single_quoted_value)
-        return decode_escapes(_single_quote_escapes, value)
+        return parse_single_quoted_value(reader)
     elif char == '"':
         (value,) = reader.read_regex(_double_quoted_value)
         return decode_escapes(_double_quote_escapes, value)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -663,6 +663,7 @@ def test_dotenv_values_file(dotenv_path):
         # With quotes
         ({"b": "c"}, 'a="${b}"', True, {"a": "c"}),
         ({"b": "c"}, "a='${b}'", True, {"a": "c"}),
+        ({}, "a='b'\"'\"'c'", True, {"a": "b'c"}),
         # With surrounding text
         ({"b": "c"}, "a=x${b}y", True, {"a": "xcy"}),
         # Self-referential

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -296,6 +296,17 @@ from dotenv.parser import Binding, Original, parse_stream
             ],
         ),
         (
+            "a='b'\"'\"'c'",
+            [
+                Binding(
+                    key="a",
+                    value="b'c",
+                    original=Original(string="a='b'\"'\"'c'", line=1),
+                    error=False,
+                )
+            ],
+        ),
+        (
             "a=à",
             [
                 Binding(


### PR DESCRIPTION
## Summary

Fixes #544. This PR adds support for bash-style single-quote splices inside `.env` values.

Before this change, `python-dotenv` failed to parse values like:

```bash
VAR='I'"'"'m a student'
```

Even though this is valid Bash and evaluates to:

```bash
I'm a student
```

After this change, `python-dotenv` accepts that form and parses it correctly. 

## What changed

- Added support for the `'"'"'` splice pattern while parsing single-quoted values
- Kept existing `\'` handling unchanged
- Added parser-level coverage for the new form
- Added `dotenv_values` coverage for the same behaviour

## Example

This now works:

```dotenv
a='b'"'"'c'
```

and is parsed as:

```text
b'c
```

## Notes

This change is intentionally narrow in scope.

It does not try to implement general shell-style concatenation. It only supports the specific splice form commonly used in Bash to embed a literal single quote inside an otherwise single-quoted string.