### PR TITLE
docs: fix broken mkdocs link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Use of pre-commit is recommended:
     $ uv run precommit install
 
 
-Documentation is published with [mkdocs]():
+Documentation is published with [mkdocs](https://www.mkdocs.org/):
 
 ```shell
 $ uv pip install -r requirements-docs.txt


### PR DESCRIPTION
Hi there! 👋

While reading through the contribution guide, I noticed the mkdocs link was empty. This small PR adds the correct URL (https://www.mkdocs.org/) to help new contributors find the documentation tool more easily.

It's a minor fix, but hopefully saves someone a Google search! 😊

Thanks for maintaining this great project - it's been super helpful in my own work.

Cheers!