### PR TITLE
Fix caching for empty dotenv files

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -74,7 +74,7 @@ class DotEnv:
 
     def dict(self) -> Dict[str, Optional[str]]:
         """Return dotenv as dict"""
-        if self._dict:
+        if self._dict is not None:
             return self._dict
 
         raw_values = self.parse()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,6 +10,7 @@ from unittest import mock
 import pytest
 
 import dotenv
+from dotenv.main import DotEnv
 
 
 def test_set_key_no_file(tmp_path):
@@ -225,6 +226,18 @@ def test_get_key_none(dotenv_path):
 
     assert result is None
     mock_warning.assert_not_called()
+
+
+def test_empty_dotenv_dict_is_cached(tmp_path):
+    dotenv_path = tmp_path / ".env"
+    dotenv_path.write_text("")
+    dotenv_obj = DotEnv(dotenv_path)
+
+    with mock.patch.object(dotenv_obj, "parse", wraps=dotenv_obj.parse) as mock_parse:
+        assert dotenv_obj.dict() == {}
+        assert dotenv_obj.dict() == {}
+
+    assert mock_parse.call_count == 1
 
 
 def test_unset_with_value(dotenv_path):


### PR DESCRIPTION
Cache the parsed dict even when the dotenv file is empty.

DotEnv.dict() previously used a truthiness check for _dict, so an empty file would be reparsed on every call. This change switches to an explicit is not None guard and adds a regression test that verifies empty dotenv contents are parsed only once.