### PR TITLE
docs: fix grammar - change 'it's' to 'its' in load_dotenv docstring

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -403,7 +403,7 @@ def load_dotenv(
         Bool: True if at least one environment variable is set else False
 
     If both `dotenv_path` and `stream` are `None`, `find_dotenv()` is used to find the
-    .env file with it's default parameters. If you need to change the default parameters
+    .env file with its default parameters. If you need to change the default parameters
     of `find_dotenv()`, you can explicitly call `find_dotenv()` and pass the result
     to this function as `dotenv_path`.
 


### PR DESCRIPTION
Hi there! 👋

This PR fixes a small grammar issue in the  docstring.

**Changes:**
- Changed "it's" (contraction of "it is") to "its" (possessive pronoun) in the docstring at line 406

This was reported in #589 - thanks to @ronytesler for catching this! 🙏

This is a documentation-only change with no functional impact.

Let me know if you'd like any adjustments! 😊