### PR TITLE
Fix `dotenv get` in case of handling of empty string values

### DIFF
--- a/src/dotenv/cli.py
+++ b/src/dotenv/cli.py
@@ -142,7 +142,7 @@ def get(ctx: click.Context, key: Any) -> None:
         values = dotenv_values(stream=stream)
 
     stored_value = values.get(key)
-    if stored_value:
+    if stored_value is not None:
         click.echo(stored_value)
     else:
         sys.exit(1)


### PR DESCRIPTION
The CLI `get` command treated empty string values as missing because it used a truthiness check. This caused keys defined as `KEY=` in `.env` files to incorrectly. The `is not None` check so existing keys with empty values are returned correctly.
