### PR TITLE
docs: clarify get_cli_string shell quoting behavior

### DIFF
--- a/src/dotenv/__init__.py
+++ b/src/dotenv/__init__.py
@@ -16,10 +16,12 @@ def get_cli_string(
     value: Optional[str] = None,
     quote: Optional[str] = None,
 ):
-    """Returns a string suitable for running as a shell script.
+    """Return a command string for invoking the dotenv CLI.
 
-    Useful for converting a arguments passed to a fabric task
-    to be passed to a `local` or `run` command.
+    This helper is intended for simple command construction and display. It does
+    not shell-escape arbitrary input. If you pass the returned string to a shell,
+    quote or validate any user-controlled values first. Prefer passing arguments as
+    a list to subprocess APIs when possible.
     """
     command = ["dotenv"]
     if quote:


### PR DESCRIPTION
## Summary

This PR clarifies the `get_cli_string()` docstring around shell usage.

The helper returns a command string for invoking the `dotenv` CLI, but it does not shell-escape arbitrary input. The updated wording makes that limitation explicit and suggests using argument-list subprocess APIs when possible.

## Changes

- Clarifies that `get_cli_string()` is intended for simple command construction/display.
- Notes that callers should quote or validate user-controlled values before passing the result to a shell.
- Avoids changing runtime behavior.

## Testing

```bash
python -m pytest tests/test_utils.py -q
python -m pytest -q
ruff check .
mypy .
````

## Compatibility

No runtime behavior changes. Documentation only.
