### PR TITLE
Fix a package build deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Strip a leading UTF-8 BOM from `.env` file contents so the first variable is no longer silently lost when the file is saved with BOM (e.g. by some JetBrains IDEs on Windows) by [@h1whelan] in [#640]
+- Fix a package build deprecation warning caused by a non-string `license` value in `pyproject.toml`.
 
 ## [1.2.2] - 2026-03-01
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Read key-value pairs from a .env file and set them as environment
 authors = [
     {name = "Saurabh Kumar", email = "me+github@saurabh-kumar.com"},
 ]
-license = { text = "BSD-3-Clause" }
+license = "BSD-3-Clause"
 keywords = [
     "environment variables",
     "deployments",


### PR DESCRIPTION
This manifests when building the package:

```
pip install build
python -m build
```

and the error is:

```
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated

********************************************************************************
Please use a simple string containing a SPDX expression for `project.license`.
You can also use `project.license-files`.

This deprecation is overdue, please update your project and remove deprecated
calls to avoid build errors in the future.

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
********************************************************************************
```