### PR TITLE
ci(security): harden CI/CD supply chain with SHA pinning and least-privilege permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,32 @@
-# Keep GitHub Actions up to date with GitHub's Dependabot...
 # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
 version: 2
 updates:
+  # Keep GitHub Actions pinned-by-SHA references up to date. Dependabot
+  # rewrites the SHA and the trailing `# vX.Y.Z` version comment together.
   - package-ecosystem: github-actions
     directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+      include: scope
     groups:
       github-actions:
         patterns:
-          - "*"  # Group all Actions updates into a single larger pull request
+          - "*"
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: pip
+    directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - dependencies
+      - python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,13 @@ on:
   release:
     types: [created]
 
+# Least-privilege default: jobs are read-only unless they opt into more below.
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # Specifying a GitHub environment is optional, but strongly encouraged
     environment: release
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
@@ -16,10 +19,10 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.x"
 
@@ -32,7 +35,7 @@ jobs:
         run: make sdist
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
       - name: Build Documentation
         run: |
@@ -41,7 +44,7 @@ jobs:
           mkdocs build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+# Least-privilege default token for every job in this workflow.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -31,10 +35,10 @@ jobs:
             python-version: "3.14"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true


### PR DESCRIPTION
## What changed

### Action pinning
All GitHub Actions SHA-pinned to full 40-char commits with `# vX.Y.Z` comments, preventing tag-hijacking attacks:

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v6` | `@de0fac2...` (`v6`) |
| `actions/setup-python` | `@v6` | `@a309ff8...` (`v6`) |
| `pypa/gh-action-pypi-publish` | `@release/v1` | `@cef2210...` (`v1.14.0`) |
| `peaceiris/actions-gh-pages` | `@v4` | `@4f9cc66...` (`v4`) |

### Least-privilege permissions
- **test.yml**: Added top-level `permissions: { contents: read }` (previously defaulted to broad read/write).
- **release.yml**: Top-level `permissions: { contents: read }`; write permissions granted only at the `publish` job level where needed.

### Dependabot
- Added `pip` ecosystem tracking (weekly).
- Added commit-message prefixes (`ci`/`chore`) and labels for easier triage.
- Added `open-pull-requests-limit` to both ecosystems.

## Why
Supply-chain attacks on GitHub Actions (e.g., codecov, tj-actions) exploit mutable tags and overly broad tokens. SHA pinning + least privilege are the standard mitigations recommended by GitHub and OpenSSF.