### PR TITLE
fix: escape backslashes in set_key so values round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `set_key` now escapes backslashes in values so values containing backslashes (e.g. Windows paths like `C:\Users`, or regexes like `\d+`) round-trip correctly through `get_key` instead of being corrupted by [@Noethix55555] in [#661]
 - Strip a leading UTF-8 BOM from `.env` file contents so the first variable is no longer silently lost when the file is saved with BOM (e.g. by some JetBrains IDEs on Windows) by [@h1whelan] in [#640]
 
 ## [1.2.2] - 2026-03-01
@@ -435,6 +436,7 @@ os.PathLike]` instead of just `os.PathLike` (#347 by [@bbc2]).
 [#497]: https://github.com/theskumar/python-dotenv/pull/497
 [#161]: https://github.com/theskumar/python-dotenv/issues/161
 [#640]: https://github.com/theskumar/python-dotenv/pull/640
+[#661]: https://github.com/theskumar/python-dotenv/issues/661
 [790c5c0]: https://github.com/theskumar/python-dotenv/commit/790c5c02991100aa1bf41ee5330aca75edc51311
 
 <!-- contributors -->
@@ -473,6 +475,7 @@ os.PathLike]` instead of just `os.PathLike` (#347 by [@bbc2]).
 [@matthewfranglen]: https://github.com/matthewfranglen
 [@mgorny]: https://github.com/mgorny
 [@naorlivne]: https://github.com/naorlivne
+[@Noethix55555]: https://github.com/Noethix55555
 [@qnighy]: https://github.com/qnighy
 [@rabinadk1]: https://github.com/rabinadk1
 [@randomseed42]: https://github.com/randomseed42

--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -216,7 +216,9 @@ def set_key(
     )
 
     if quote:
-        value_out = "'{}'".format(value_to_set.replace("'", "\\'"))
+        value_out = "'{}'".format(
+            value_to_set.replace("\\", "\\\\").replace("'", "\\'")
+        )
     else:
         value_out = value_to_set
     if export:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -54,6 +54,23 @@ def test_set_key(dotenv_path, before, key, value, expected, after):
     mock_warning.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "C:\\Users",
+        "\\d+",
+        "\\",
+        "a\\b",
+        "a\\\\b",
+        "back\\slash and 'quote'",
+    ],
+)
+def test_set_key_roundtrip_with_backslashes(dotenv_path, value):
+    dotenv.set_key(dotenv_path, "a", value)
+
+    assert dotenv.get_key(dotenv_path, "a") == value
+
+
 def test_set_key_encoding(dotenv_path):
     encoding = "latin-1"
 


### PR DESCRIPTION
## Summary

`set_key` writes single-quoted values but only escapes single quotes, not backslashes. Because the single-quoted-value parser treats `\` as an escape character (decoding `\\` -> `\` and `\'` -> `'`), any value containing a backslash is corrupted on round-trip through `get_key`.

```python
import dotenv

dotenv.set_key(".env", "PATH", r"C:\Users")
dotenv.get_key(".env", "PATH")   # before: "C:Users"  (backslash lost)

dotenv.set_key(".env", "RE", r"\d+")
dotenv.get_key(".env", "RE")      # before: "d+"
```

This affects Windows paths and regular expressions in particular.

## Fix

Escape backslashes before escaping single quotes in `set_key`:

```python
value_out = "'{}'".format(
    value_to_set.replace("\\", "\\\\").replace("'", "\\'")
)
```

This mirrors how the parser unescapes values, so writes round-trip.

## Tests

Added a parametrized round-trip regression test (`test_set_key_roundtrip_with_backslashes`) covering `C:\Users`, `\d+`, `\`, `a\b`, `a\\b`, and a backslash+quote combination. Verified it fails on `main` and passes with the fix. The existing `test_set_key` cases and the rest of the suite remain green.

Closes #661
