### PR TITLE
fix: parse empty unquoted value with inline comment as empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- An unquoted empty value followed by an inline comment (e.g. `KEY= # comment`) is now parsed as an empty string instead of the comment text by [@Noethix55555] in [#600]
 - Strip a leading UTF-8 BOM from `.env` file contents so the first variable is no longer silently lost when the file is saved with BOM (e.g. by some JetBrains IDEs on Windows) by [@h1whelan] in [#640]
 
 ## [1.2.2] - 2026-03-01
@@ -434,6 +435,7 @@ os.PathLike]` instead of just `os.PathLike` (#347 by [@bbc2]).
 [#563]: https://github.com/theskumar/python-dotenv/pull/563
 [#497]: https://github.com/theskumar/python-dotenv/pull/497
 [#161]: https://github.com/theskumar/python-dotenv/issues/161
+[#600]: https://github.com/theskumar/python-dotenv/issues/600
 [#640]: https://github.com/theskumar/python-dotenv/pull/640
 [790c5c0]: https://github.com/theskumar/python-dotenv/commit/790c5c02991100aa1bf41ee5330aca75edc51311
 
@@ -473,6 +475,7 @@ os.PathLike]` instead of just `os.PathLike` (#347 by [@bbc2]).
 [@matthewfranglen]: https://github.com/matthewfranglen
 [@mgorny]: https://github.com/mgorny
 [@naorlivne]: https://github.com/naorlivne
+[@Noethix55555]: https://github.com/Noethix55555
 [@qnighy]: https://github.com/qnighy
 [@rabinadk1]: https://github.com/rabinadk1
 [@randomseed42]: https://github.com/randomseed42

--- a/src/dotenv/parser.py
+++ b/src/dotenv/parser.py
@@ -154,8 +154,15 @@ def parse_binding(reader: Reader) -> Binding:
         key = parse_key(reader)
         reader.read_regex(_whitespace)
         if reader.peek(1) == "=":
-            reader.read_regex(_equal_sign)
-            value: Optional[str] = parse_value(reader)
+            (equal_sign,) = reader.read_regex(_equal_sign)
+            # If there is whitespace after `=` and the value starts with `#`,
+            # the value is empty and the rest of the line is an inline comment
+            # (e.g. `KEY= # comment`). Without whitespace (`KEY=#novalue`) the
+            # `#` is part of the unquoted value.
+            if len(equal_sign) > 1 and reader.peek(1) == "#":
+                value: Optional[str] = ""
+            else:
+                value = parse_value(reader)
         else:
             value = None
         reader.read_regex(_comment)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -708,3 +708,19 @@ def test_dotenv_values_file_stream(dotenv_path):
         result = dotenv.dotenv_values(stream=f)
 
     assert result == {"a": "b"}
+
+
+@pytest.mark.parametrize(
+    "string,expected",
+    [
+        ("KEY= # comment", {"KEY": ""}),
+        ("KEY=  # comment", {"KEY": ""}),
+        ("KEY=val # comment", {"KEY": "val"}),
+        ("KEY=a#b", {"KEY": "a#b"}),
+        ("KEY=#novalue", {"KEY": "#novalue"}),
+    ],
+)
+def test_dotenv_values_empty_value_with_inline_comment(string, expected):
+    result = dotenv.dotenv_values(stream=io.StringIO(string))
+
+    assert result == expected

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -120,6 +120,39 @@ from dotenv.parser import Binding, Original, parse_stream
             ],
         ),
         (
+            "a= #b",
+            [
+                Binding(
+                    key="a",
+                    value="",
+                    original=Original(string="a= #b", line=1),
+                    error=False,
+                )
+            ],
+        ),
+        (
+            "a=  # b",
+            [
+                Binding(
+                    key="a",
+                    value="",
+                    original=Original(string="a=  # b", line=1),
+                    error=False,
+                )
+            ],
+        ),
+        (
+            "a=#b",
+            [
+                Binding(
+                    key="a",
+                    value="#b",
+                    original=Original(string="a=#b", line=1),
+                    error=False,
+                )
+            ],
+        ),
+        (
             "a=b c",
             [
                 Binding(


### PR DESCRIPTION
## Summary

Fixes #600.

An unquoted empty value followed by an inline comment is parsed as the comment text instead of an empty string:

```python
from io import StringIO
from dotenv import dotenv_values

dotenv_values(stream=StringIO("KEY= # comment"))
# before: {'KEY': '# comment'}
# after:  {'KEY': ''}
```

## Root cause

`_equal_sign = (=[^\S\r\n]*)` consumes the whitespace after `=`, so the captured unquoted value is `# comment` with no leading whitespace. `parse_unquoted_value` strips comments with `re.sub(r"\s+#.*", "", part)`, which requires whitespace before `#` and therefore does not strip it.

## Fix

In `parse_binding`, after reading the equal sign, if it consumed trailing whitespace (so the value is empty) and the next character is `#`, treat the value as `""` and let the rest of the line be parsed as a comment. When there is no space before `#` (e.g. `KEY=#novalue`, `KEY=a#b`) the `#` remains part of the value, preserving existing behavior.

## Behavior preserved (with tests)

- `KEY=val # comment` -> `val`
- `KEY=a#b` -> `a#b` (no space before `#`)
- `KEY=#novalue` -> `#novalue` (no space, unchanged)
- `KEY= # comment` / `KEY=  # comment` -> `''` (the fix)
- Trailing/leading whitespace handling on normal values unchanged (e.g. ` a = b ` -> `b`, `a=b c ` -> `b c`)

## Tests

Added parametrized cases in `tests/test_parser.py` (`a= #b`, `a=  # b`, `a=#b`) and an end-to-end `dotenv_values` regression in `tests/test_main.py`. Verified they fail on `main` and pass with the fix. Full test suite remains green.
