### PR TITLE
fix: escape backslashes in set_key to preserve round-trip

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -216,7 +216,9 @@ def set_key(
     )
 
     if quote:
-        value_out = "'{}'".format(value_to_set.replace("'", "\\'"))
+        value_out = "'{}'".format(
+            value_to_set.replace("\\", "\\\\").replace("'", "\\'")
+        )
     else:
         value_out = value_to_set
     if export:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -54,6 +54,29 @@ def test_set_key(dotenv_path, before, key, value, expected, after):
     mock_warning.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("a", "no backslash"),
+        ("b", r"one \ backslash"),
+        ("c", r"two \\ backslashes"),
+        ("d", r"three \\\ backslashes"),
+        ("e", r"path C:\Users\test"),
+        ("f", r"mix ' quote and \\ backslashes"),
+    ],
+)
+def test_set_key_backslash_roundtrip(tmp_path, key, value):
+    """set_key must round-trip values containing backslashes (gh-issue)."""
+    dotenv_path = tmp_path / ".env"
+    dotenv_path.write_text("")
+
+    dotenv.set_key(dotenv_path, key, value)
+    result = dotenv.dotenv_values(dotenv_path)
+    assert result.get(key) == value, (
+        f"Round-trip failed: {value!r} -> {result.get(key)!r}"
+    )
+
+
 def test_set_key_encoding(dotenv_path):
     encoding = "latin-1"
 


### PR DESCRIPTION
## Bug

`set_key()` writes values wrapped in single quotes, and the parser decodes `\\` as a literal backslash via `decode_escapes()`. But `set_key()` only escaped single-quote characters (`\'`), not backslashes themselves. This meant any value containing two or more consecutive backslashes lost one during round-trip:



Also reproduces for Windows paths (`C:\Users\...`) and any value with `\\` sequences.

## Root Cause

The parser's `_single_quote_escapes` regex matches both `\'` and `\\`, decoding them via `codecs.decode(..., 'unicode-escape')`. When `set_key` writes a value containing literal `\\`, the parser interprets it as an escaped backslash and decodes it to `\`, losing one backslash on each consecutive pair.

## Fix

Escape backslashes in addition to single-quotes in `set_key()`, before wrapping in single quotes. The order is important: backslashes must be escaped first (`\\` -> `\\\\`), then single-quotes (`'` -> `\'`).

## Diff

- `src/dotenv/main.py`: +2/-0 (escape backslashes before single-quotes)
- `tests/test_main.py`: +23 (parametrized round-trip regression test covering 0-3 backslashes, Windows paths, and mixed quotes+backslashes)