### PR TITLE
Handle CRLF invalid lines in parser recovery

### DIFF
--- a/src/dotenv/parser.py
+++ b/src/dotenv/parser.py
@@ -27,7 +27,7 @@ _double_quoted_value = make_regex(r'"((?:\\"|[^"])*)"')
 _unquoted_value = make_regex(r"([^\r\n]*)")
 _comment = make_regex(r"(?:[^\S\r\n]*#[^\r\n]*)?")
 _end_of_line = make_regex(r"[^\S\r\n]*(?:\r\n|\n|\r|$)")
-_rest_of_line = make_regex(r"[^\r\n]*(?:\r|\n|\r\n)?")
+_rest_of_line = make_regex(r"[^\r\n]*(?:\r\n|\n|\r)?")
 _double_quote_escapes = make_regex(r"\\[\\'\"abfnrtv]")
 _single_quote_escapes = make_regex(r"\\[\\']")
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -340,6 +340,23 @@ from dotenv.parser import Binding, Original, parse_stream
             ],
         ),
         (
+            "a: b\r\nc=d",
+            [
+                Binding(
+                    key=None,
+                    value=None,
+                    original=Original(string="a: b\r\n", line=1),
+                    error=True,
+                ),
+                Binding(
+                    key="c",
+                    value="d",
+                    original=Original(string="c=d", line=2),
+                    error=False,
+                ),
+            ],
+        ),
+        (
             "a=b\nc=d",
             [
                 Binding(


### PR DESCRIPTION
## What changed

This updates the parser recovery regex for invalid lines so CRLF is consumed as one newline sequence, matching the parser's other newline handling.

## Why

When an invalid `.env` line used CRLF line endings, `_rest_of_line` matched `\r` before `\r\n`. That left the `\n` behind for the next parse iteration, so recovery could produce an extra blank binding before the following valid line.

## Validation

- `PYTHONPATH=src python -m pytest tests\test_parser.py::test_parse_stream -q`
- `PYTHONPATH=src python -m pytest tests\test_parser.py -q`
- `python -m ruff check src\dotenv\parser.py tests\test_parser.py`
- `git diff --check`