### PR TITLE
Strip inline comment from an empty unquoted value

### DIFF
--- a/src/dotenv/parser.py
+++ b/src/dotenv/parser.py
@@ -120,12 +120,18 @@ def parse_key(reader: Reader) -> Optional[str]:
     return key
 
 
-def parse_unquoted_value(reader: Reader) -> str:
+def parse_unquoted_value(reader: Reader, preceded_by_whitespace: bool = False) -> str:
     (part,) = reader.read_regex(_unquoted_value)
+    # A value that is only an inline comment (e.g. ``KEY=  # comment``) is empty.
+    # The whitespace before the ``#`` is consumed by the equal-sign match, so the
+    # ``preceded_by_whitespace`` flag is what distinguishes this from a value that
+    # legitimately starts with ``#`` (e.g. ``KEY=#value``).
+    if preceded_by_whitespace and part.startswith("#"):
+        return ""
     return re.sub(r"\s+#.*", "", part).rstrip()
 
 
-def parse_value(reader: Reader) -> str:
+def parse_value(reader: Reader, preceded_by_whitespace: bool = False) -> str:
     char = reader.peek(1)
     if char == "'":
         (value,) = reader.read_regex(_single_quoted_value)
@@ -136,7 +142,7 @@ def parse_value(reader: Reader) -> str:
     elif char in ("", "\n", "\r"):
         return ""
     else:
-        return parse_unquoted_value(reader)
+        return parse_unquoted_value(reader, preceded_by_whitespace)
 
 
 def parse_binding(reader: Reader) -> Binding:
@@ -154,8 +160,12 @@ def parse_binding(reader: Reader) -> Binding:
         key = parse_key(reader)
         reader.read_regex(_whitespace)
         if reader.peek(1) == "=":
-            reader.read_regex(_equal_sign)
-            value: Optional[str] = parse_value(reader)
+            (equal_sign,) = reader.read_regex(_equal_sign)
+            # ``_equal_sign`` captures the ``=`` plus any horizontal whitespace,
+            # so a length > 1 means the value was separated from ``=`` by spaces.
+            value: Optional[str] = parse_value(
+                reader, preceded_by_whitespace=len(equal_sign) > 1
+            )
         else:
             value = None
         reader.read_regex(_comment)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -109,6 +109,39 @@ from dotenv.parser import Binding, Original, parse_stream
             ],
         ),
         (
+            "a= #c",
+            [
+                Binding(
+                    key="a",
+                    value="",
+                    original=Original(string="a= #c", line=1),
+                    error=False,
+                )
+            ],
+        ),
+        (
+            "a=  # comment",
+            [
+                Binding(
+                    key="a",
+                    value="",
+                    original=Original(string="a=  # comment", line=1),
+                    error=False,
+                )
+            ],
+        ),
+        (
+            "a=#b",
+            [
+                Binding(
+                    key="a",
+                    value="#b",
+                    original=Original(string="a=#b", line=1),
+                    error=False,
+                )
+            ],
+        ),
+        (
             "a=b\t#c",
             [
                 Binding(


### PR DESCRIPTION
Fixes #600.

For a line where the key has an empty value followed by an inline comment, the comment text became the value:

```python
>>> dotenv_values(stream=io.StringIO("EMPTY_VALUE=  # comment"))["EMPTY_VALUE"]
'# comment'   # expected ''
```

`parse_unquoted_value()` strips inline comments with `re.sub(r"\s+#.*", "", part)`, which requires whitespace *before* the `#`. But `_equal_sign` (`=[^\S\r\n]*`) consumes the whitespace between `=` and the value, so for an empty value the remaining text starts at `#` with no leading whitespace, and the strip never matches.

The whitespace *was* there in the source, though — it's just been consumed. This threads a `preceded_by_whitespace` flag (derived from whether the `_equal_sign` match captured any whitespace) so that:

- `KEY=  # comment` / `KEY= #c` → `""` (empty value, comment stripped)
- `KEY=#value` → `"#value"` (no separating whitespace, so `#` is part of the value — unchanged)
- `KEY=v # c` → `"v"`, `KEY=v#c` → `"v#c"` — all unchanged

New parser test cases cover `a= #c`, `a=  # comment`, and `a=#b`. Full suite: `tests/test_parser.py` `48 passed`; `tests/test_main.py` unaffected. `ruff` clean.