### PR TITLE
fix: read the .env file as UTF-8 in the CLI

### DIFF
--- a/src/dotenv/cli.py
+++ b/src/dotenv/cli.py
@@ -73,7 +73,7 @@ def stream_file(path: os.PathLike) -> Iterator[IO[str]]:
     """
 
     try:
-        with open(path) as stream:
+        with open(path, encoding="utf-8") as stream:
             yield stream
     except OSError as exc:
         print(f"Error opening env file: {exc}", file=sys.stderr)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,15 @@ def test_list(
     assert (result.exit_code, result.output) == (0, expected)
 
 
+def test_list_non_ascii_value(cli, dotenv_path):
+    """`list` must read the file as UTF-8, like the library API does."""
+    dotenv_path.write_text("a=Köln\n", encoding="utf-8")
+
+    result = cli.invoke(dotenv_cli, ["--file", dotenv_path, "list"])
+
+    assert (result.exit_code, result.output) == (0, "a=Köln\n")
+
+
 def test_list_non_existent_file(cli):
     result = cli.invoke(dotenv_cli, ["--file", "nx_file", "list"])
 
@@ -65,6 +74,15 @@ def test_get_existing_value(cli, dotenv_path):
     result = cli.invoke(dotenv_cli, ["--file", dotenv_path, "get", "a"])
 
     assert (result.exit_code, result.output) == (0, "b\n")
+
+
+def test_get_non_ascii_value(cli, dotenv_path):
+    """`get` must read the file as UTF-8, like the library API does."""
+    dotenv_path.write_text("a=Köln\n", encoding="utf-8")
+
+    result = cli.invoke(dotenv_cli, ["--file", dotenv_path, "get", "a"])
+
+    assert (result.exit_code, result.output) == (0, "Köln\n")
 
 
 def test_get_non_existent_value(cli, dotenv_path):


### PR DESCRIPTION
## What

`dotenv list` and `dotenv get` decode the `.env` file with the locale encoding instead of
UTF-8, so a UTF-8 file containing non-ASCII values is silently mis-decoded.

`stream_file` in `src/dotenv/cli.py` opened the file with no `encoding`:

```python
with open(path) as stream:
```

so it falls back to `locale.getpreferredencoding(False)` — cp1252 on a typical Windows
install. The library API does not have this problem: `get_key`, `set_key`, `unset_key`,
`load_dotenv` and `dotenv_values` all default to `encoding="utf-8"`.

## Reproduction

A UTF-8 `.env`:

```
NAME=Zoë
CITY=Köln
```

Library API — correct:

```console
$ python -c "import dotenv; print(dotenv.get_key('.env','NAME'), dotenv.get_key('.env','CITY'))"
Zoë Köln
```

CLI — silently wrong, and still exits 0:

```console
$ python -m dotenv --file .env list
CITY=KÃ¶ln
NAME=ZoÃ«
$ echo $LASTEXITCODE
0
```

The silence is the part that bites: there is no `UnicodeDecodeError` to notice, so anything
consuming `dotenv list` / `dotenv get` output just receives corrupted values.

## Fix

```python
with open(path, encoding="utf-8") as stream:
```

This matches the default deliberately chosen for the library in #306 ("Use UTF-8 as default
encoding"), which fixed the same class of problem for `load_dotenv` after #300 reported it
on Windows. The CLI path was simply not covered by that change. Two commands are affected,
`list` and `get` — both go through `stream_file`.

I kept this to the encoding default rather than adding a `--encoding` CLI option, to stay in
scope; happy to add one if you would like it.

## Tests

Two regression tests added, mirroring the existing `test_list` / `test_get_existing_value`
style:

- `test_list_non_ascii_value`
- `test_get_non_ascii_value`

Both fail on `main` and pass with the fix:

```console
# with the source change reverted, tests kept
FAILED tests/test_cli.py::test_list_non_ascii_value - AssertionError: assert (0, 'a=KÃ¶ln\n') == (0, 'a=Köln\n')
FAILED tests/test_cli.py::test_get_non_ascii_value  - AssertionError: assert (0, 'KÃ¶ln\n')  == (0, 'Köln\n')
2 failed

# with the fix
2 passed
```

Full suite on this machine: `169 passed, 48 skipped` (167 before, plus these two).

Six `test_cli.py::test_run_*` tests fail locally for an unrelated reason — they shell out to
`printenv`, which is not present on this Windows host. They pass on your CI, where the
Windows runners provide coreutils, so I have left them alone.

`ruff check` and `ruff format --check` are clean on both changed files.
