### PR TITLE
Reject a key that set_key cannot write faithfully

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -190,6 +190,21 @@ def rewrite(
         raise error from None
 
 
+def _is_writable_key(key: str, export: bool = False) -> bool:
+    """
+    Whether ``key`` survives a write and read round trip through the parser.
+
+    ``set_key`` interpolates the key into the line it writes, so a key the
+    parser reads back differently, or not at all, would silently store a
+    different variable than the caller asked for. Rather than restating the
+    parser's rules here, write a probe line with a trivial value and check that
+    the parser hands the same key back.
+    """
+    prefix = "export " if export else ""
+    bindings = list(parse_stream(io.StringIO(f"{prefix}{key}=x\n")))
+    return len(bindings) == 1 and bindings[0].key == key
+
+
 def set_key(
     dotenv_path: StrPath,
     key_to_set: str,
@@ -210,6 +225,9 @@ def set_key(
     """
     if quote_mode not in ("always", "auto", "never"):
         raise ValueError(f"Unknown quote_mode: {quote_mode}")
+
+    if not _is_writable_key(key_to_set, export=export):
+        raise ValueError(f"Invalid key: {key_to_set!r}")
 
     quote = quote_mode == "always" or (
         quote_mode == "auto" and not value_to_set.isalnum()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -756,3 +756,36 @@ def test_dotenv_values_empty_value_with_inline_comment(string, expected):
     result = dotenv.dotenv_values(stream=io.StringIO(string))
 
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "a=b",  # written verbatim, reads back as key "a" with value "b='x'"
+        "a b",
+        " a",
+        "a\tb",
+        "a#b",
+        "",
+        "a\nb",  # writes a second line, so a spurious extra key appears
+        "export A",
+    ],
+)
+def test_set_key_rejects_key_that_does_not_round_trip(tmp_path, key):
+    dotenv_path = tmp_path / ".env"
+    dotenv_path.write_text("EXISTING=1\n")
+
+    with pytest.raises(ValueError):
+        dotenv.set_key(dotenv_path, key, "x")
+
+    assert dotenv_path.read_text() == "EXISTING=1\n"
+
+
+@pytest.mark.parametrize("key", ["a", "A_B1", "a.b", "MY-KEY", "a'b", "a$b", "\u00e9"])
+def test_set_key_accepts_key_that_round_trips(tmp_path, key):
+    dotenv_path = tmp_path / ".env"
+
+    result = dotenv.set_key(dotenv_path, key, "x")
+
+    assert result == (True, key, "x")
+    assert dotenv.dotenv_values(dotenv_path) == {key: "x"}


### PR DESCRIPTION
`set_key` validates `quote_mode` and quotes the value it writes, but nothing validates the key. The key is interpolated straight into the line, so a key the parser reads back differently is silently stored as a *different variable*, while the call returns `(True, key, value)` to report success.

```python
>>> from dotenv import set_key, dotenv_values
>>> set_key(".env", "a=b", "x")
(True, 'a=b', 'x')
>>> open(".env").read()
"a=b='x'\n"
>>> dotenv_values(".env")
{'a': "b='x'"}
```

The caller asked for key `a=b` and got key `a` holding `b='x'`.

Other shapes are lost outright rather than altered. `"a b"`, `" a"`, `"a\tb"` and `""` write lines the parser rejects, so the key silently does not exist afterwards; `"a\nb"` writes a second line, so a spurious extra key appears. Each returns `True`.

All of it is reachable from the CLI:

```console
$ dotenv -f .env set "a=b" x
a=b=x
$ echo $?
0
$ dotenv -f .env list
a=b='x'
```

## The change

Validate by round trip rather than by restating the parser's rules in a second place: write a probe line with a trivial value and check that the parser hands the same key back. If the parser and `set_key` ever disagree about what a key is, this check follows the parser automatically.

Keys that work today are unaffected. The added test pins that explicitly for `a`, `A_B1`, `a.b`, `MY-KEY`, `a'b`, `a$b` and a non-ASCII key.

`ValueError` matches the existing behaviour for a bad `quote_mode` a few lines above.

Scope is deliberately the key only. The value side of `quote_mode="never"` is #218, which you closed after #330, and this change does not touch it.

## Verification

Against `main` at `751f8c14`:

- The two added tests, applied alone to unmodified `main`: **8 failed, 7 passed**. The 8 failures are exactly the 8 rejection cases; the 7 passes are the control keys, which already round-trip correctly.
- With the change: **235 passed, 1 skipped** (the suite was 220 passed, 1 skipped before the 15 added cases).
- `ruff check .`, `ruff format --check src tests` and `mypy src` all clean.
