### PR TITLE
fix: do not treat an inline comment as an empty value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Strip a leading UTF-8 BOM from `.env` file contents so the first variable is no longer silently lost when the file is saved with BOM (e.g. by some JetBrains IDEs on Windows) by [@h1whelan] in [#640]
+- Treat an inline comment that follows an empty unquoted value as a comment rather than the value, so `KEY=  # comment` parses to `""` instead of `"# comment"` by [@dchaudhari7177] in [#600]
 
 ## [1.2.2] - 2026-03-01
 
@@ -435,6 +436,7 @@ os.PathLike]` instead of just `os.PathLike` (#347 by [@bbc2]).
 [#497]: https://github.com/theskumar/python-dotenv/pull/497
 [#161]: https://github.com/theskumar/python-dotenv/issues/161
 [#640]: https://github.com/theskumar/python-dotenv/pull/640
+[#600]: https://github.com/theskumar/python-dotenv/issues/600
 [790c5c0]: https://github.com/theskumar/python-dotenv/commit/790c5c02991100aa1bf41ee5330aca75edc51311
 
 <!-- contributors -->
@@ -452,6 +454,7 @@ os.PathLike]` instead of just `os.PathLike` (#347 by [@bbc2]).
 [@bbc2]: https://github.com/bbc2
 [@befeleme]: https://github.com/befeleme
 [@cjauvin]: https://github.com/cjauvin
+[@dchaudhari7177]: https://github.com/dchaudhari7177
 [@eaf]: https://github.com/eaf
 [@earlbread]: https://github.com/earlbread
 [@eekstunt]: https://github.com/eekstunt

--- a/src/dotenv/parser.py
+++ b/src/dotenv/parser.py
@@ -120,12 +120,17 @@ def parse_key(reader: Reader) -> Optional[str]:
     return key
 
 
-def parse_unquoted_value(reader: Reader) -> str:
+def parse_unquoted_value(reader: Reader, preceded_by_whitespace: bool = False) -> str:
     (part,) = reader.read_regex(_unquoted_value)
+    # An unquoted value only ends at a `#` that is preceded by whitespace. The
+    # whitespace right after the `=` is consumed by `_equal_sign`, so a value
+    # starting with `#` is a comment only if that whitespace was there.
+    if preceded_by_whitespace and part.startswith("#"):
+        return ""
     return re.sub(r"\s+#.*", "", part).rstrip()
 
 
-def parse_value(reader: Reader) -> str:
+def parse_value(reader: Reader, preceded_by_whitespace: bool = False) -> str:
     char = reader.peek(1)
     if char == "'":
         (value,) = reader.read_regex(_single_quoted_value)
@@ -136,7 +141,7 @@ def parse_value(reader: Reader) -> str:
     elif char in ("", "\n", "\r"):
         return ""
     else:
-        return parse_unquoted_value(reader)
+        return parse_unquoted_value(reader, preceded_by_whitespace)
 
 
 def parse_binding(reader: Reader) -> Binding:
@@ -154,8 +159,10 @@ def parse_binding(reader: Reader) -> Binding:
         key = parse_key(reader)
         reader.read_regex(_whitespace)
         if reader.peek(1) == "=":
-            reader.read_regex(_equal_sign)
-            value: Optional[str] = parse_value(reader)
+            (equal_sign,) = reader.read_regex(_equal_sign)
+            value: Optional[str] = parse_value(
+                reader, preceded_by_whitespace=len(equal_sign) > 1
+            )
         else:
             value = None
         reader.read_regex(_comment)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -120,6 +120,56 @@ from dotenv.parser import Binding, Original, parse_stream
             ],
         ),
         (
+            "a= #c",
+            [
+                Binding(
+                    key="a",
+                    value="",
+                    original=Original(string="a= #c", line=1),
+                    error=False,
+                )
+            ],
+        ),
+        (
+            "a=\t#c",
+            [
+                Binding(
+                    key="a",
+                    value="",
+                    original=Original(string="a=\t#c", line=1),
+                    error=False,
+                )
+            ],
+        ),
+        (
+            "a=#c",
+            [
+                Binding(
+                    key="a",
+                    value="#c",
+                    original=Original(string="a=#c", line=1),
+                    error=False,
+                )
+            ],
+        ),
+        (
+            "a= #c\nd=e",
+            [
+                Binding(
+                    key="a",
+                    value="",
+                    original=Original(string="a= #c\n", line=1),
+                    error=False,
+                ),
+                Binding(
+                    key="d",
+                    value="e",
+                    original=Original(string="d=e", line=2),
+                    error=False,
+                ),
+            ],
+        ),
+        (
             "a=b c",
             [
                 Binding(


### PR DESCRIPTION
Fixes #600.

## Problem

An inline comment after an empty unquoted value becomes the value:

```python
>>> dotenv_values(stream=io.StringIO("WITH_VALUE=hello  # c\nEMPTY_VALUE=  # c\n"))
OrderedDict({'WITH_VALUE': 'hello', 'EMPTY_VALUE': '# c'})
```

`EMPTY_VALUE` should be `''`, the same way `WITH_VALUE` gets its comment stripped.

## Cause

`_equal_sign` is `(=[^\S\r\n]*)`, so it consumes the horizontal whitespace right after `=`. `parse_unquoted_value` then strips comments with `re.sub(r"\s+#.*", "", part)`, which requires whitespace *before* the `#`. For `KEY=  # c` that whitespace is already gone, the part is `# c` with the `#` at position 0, the substitution does not fire, and the comment is returned as the value.

## Fix

`parse_binding` already gets the matched `=` plus whitespace back from `read_regex`, so it can tell whether any whitespace followed the `=`. That flag is threaded to `parse_unquoted_value`, which treats a part starting with `#` as a comment only when the whitespace was there.

This keeps the existing rule that `#` starts a comment only when preceded by whitespace, so `a=b#c` and the newly-covered `a=#c` both still parse to a literal value containing the `#`.

| Input | Before | After |
|---|---|---|
| `a=b # c` | `b` | `b` |
| `a= # c` | `# c` | `` (empty) |
| `a=#c` | `#c` | `#c` |
| `a=b#c` | `b#c` | `b#c` |
| `a=` | `` (empty) | `` (empty) |

## Tests

Four cases added to `test_parse_stream`, including the no-whitespace `a=#c` case that pins the unchanged behaviour and a two-binding case confirming the reader is left in the right position.

`pytest tests/` passes. The two `test_cli.py::test_run_*` failures on my machine are pre-existing and Windows-specific (they reproduce on an unmodified checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)