### PR TITLE
fix: make values containing backslashes round-trip through set_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Strip a leading UTF-8 BOM from `.env` file contents so the first variable is no longer silently lost when the file is saved with BOM (e.g. by some JetBrains IDEs on Windows) by [@h1whelan] in [#640]
+- `set_key` now escapes backslashes, so values containing them (Windows paths, regular expressions) survive a write/read round-trip. Quoted values ending in an escaped backslash are no longer mis-parsed as an escaped quote, which used to swallow the following lines by [@dchaudhari7177] in [#661]
 
 ## [1.2.2] - 2026-03-01
 
@@ -435,6 +436,7 @@ os.PathLike]` instead of just `os.PathLike` (#347 by [@bbc2]).
 [#497]: https://github.com/theskumar/python-dotenv/pull/497
 [#161]: https://github.com/theskumar/python-dotenv/issues/161
 [#640]: https://github.com/theskumar/python-dotenv/pull/640
+[#661]: https://github.com/theskumar/python-dotenv/issues/661
 [790c5c0]: https://github.com/theskumar/python-dotenv/commit/790c5c02991100aa1bf41ee5330aca75edc51311
 
 <!-- contributors -->
@@ -452,6 +454,7 @@ os.PathLike]` instead of just `os.PathLike` (#347 by [@bbc2]).
 [@bbc2]: https://github.com/bbc2
 [@befeleme]: https://github.com/befeleme
 [@cjauvin]: https://github.com/cjauvin
+[@dchaudhari7177]: https://github.com/dchaudhari7177
 [@eaf]: https://github.com/eaf
 [@earlbread]: https://github.com/earlbread
 [@eekstunt]: https://github.com/eekstunt

--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -216,7 +216,12 @@ def set_key(
     )
 
     if quote:
-        value_out = "'{}'".format(value_to_set.replace("'", "\\'"))
+        # The single-quoted-value parser decodes `\\` and `\'`, so both have to
+        # be escaped here for the value to survive a write/read round-trip.
+        # Backslashes first, otherwise the backslash added by the quote
+        # escaping would be escaped in turn.
+        escaped = value_to_set.replace("\\", "\\\\").replace("'", "\\'")
+        value_out = f"'{escaped}'"
     else:
         value_out = value_to_set
     if export:

--- a/src/dotenv/parser.py
+++ b/src/dotenv/parser.py
@@ -22,8 +22,10 @@ _export = make_regex(r"(?:export[^\S\r\n]+)?")
 _single_quoted_key = make_regex(r"'([^']+)'")
 _unquoted_key = make_regex(r"([^=\#\s]+)")
 _equal_sign = make_regex(r"(=[^\S\r\n]*)")
-_single_quoted_value = make_regex(r"'((?:\\'|[^'])*)'")
-_double_quoted_value = make_regex(r'"((?:\\"|[^"])*)"')
+# A backslash always escapes the character after it, so that an escaped
+# backslash (`\\`) is not mistaken for the start of an escaped quote.
+_single_quoted_value = make_regex(r"'((?:\\.|[^'\\])*)'", extra_flags=re.DOTALL)
+_double_quoted_value = make_regex(r'"((?:\\.|[^"\\])*)"', extra_flags=re.DOTALL)
 _unquoted_value = make_regex(r"([^\r\n]*)")
 _comment = make_regex(r"(?:[^\S\r\n]*#[^\r\n]*)?")
 _end_of_line = make_regex(r"[^\S\r\n]*(?:\r\n|\n|\r|$)")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -40,6 +40,9 @@ def test_set_key_no_file(tmp_path):
         ("a=b\nc=d\ne=f", "c", "g", (True, "c", "g"), "a=b\nc='g'\ne=f"),
         ("a=b\n", "c", "d", (True, "c", "d"), "a=b\nc='d'\n"),
         ("a=b", "c", "d", (True, "c", "d"), "a=b\nc='d'\n"),
+        ("", "a", "b\\c", (True, "a", "b\\c"), "a='b\\\\c'\n"),
+        ("", "a", "b\\", (True, "a", "b\\"), "a='b\\\\'\n"),
+        ("", "a", "b\\'c", (True, "a", "b\\'c"), "a='b\\\\\\'c'\n"),
     ],
 )
 def test_set_key(dotenv_path, before, key, value, expected, after):
@@ -52,6 +55,32 @@ def test_set_key(dotenv_path, before, key, value, expected, after):
     assert result == expected
     assert dotenv_path.read_text() == after
     mock_warning.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "C:\\Users",
+        "C:\\Users\\",
+        "\\d+",
+        "back\\",
+        "a\\'b",
+        "it's",
+        'say "hi"',
+        "a\\nb",
+        "plain",
+        "",
+    ],
+)
+def test_set_key_round_trips(dotenv_path, value):
+    dotenv_path.write_text("")
+
+    dotenv.set_key(dotenv_path, "a", value)
+    dotenv.set_key(dotenv_path, "b", "sentinel")
+
+    assert dotenv.get_key(dotenv_path, "a") == value
+    # A value that is mis-tokenized can swallow the lines that follow it.
+    assert dotenv.get_key(dotenv_path, "b") == "sentinel"
 
 
 def test_set_key_encoding(dotenv_path):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -296,6 +296,75 @@ from dotenv.parser import Binding, Original, parse_stream
             ],
         ),
         (
+            "a='b\\\\c'",
+            [
+                Binding(
+                    key="a",
+                    value="b\\c",
+                    original=Original(string="a='b\\\\c'", line=1),
+                    error=False,
+                )
+            ],
+        ),
+        (
+            'a="b\\\\c"',
+            [
+                Binding(
+                    key="a",
+                    value="b\\c",
+                    original=Original(string='a="b\\\\c"', line=1),
+                    error=False,
+                )
+            ],
+        ),
+        # An escaped backslash at the end of the value must not be read as the
+        # start of an escaped quote, which would swallow the following lines.
+        (
+            "a='b\\\\'\nc='d'",
+            [
+                Binding(
+                    key="a",
+                    value="b\\",
+                    original=Original(string="a='b\\\\'\n", line=1),
+                    error=False,
+                ),
+                Binding(
+                    key="c",
+                    value="d",
+                    original=Original(string="c='d'", line=2),
+                    error=False,
+                ),
+            ],
+        ),
+        (
+            'a="b\\\\"\nc="d"',
+            [
+                Binding(
+                    key="a",
+                    value="b\\",
+                    original=Original(string='a="b\\\\"\n', line=1),
+                    error=False,
+                ),
+                Binding(
+                    key="c",
+                    value="d",
+                    original=Original(string='c="d"', line=2),
+                    error=False,
+                ),
+            ],
+        ),
+        (
+            "a='b\\\\\\'c'",
+            [
+                Binding(
+                    key="a",
+                    value="b\\'c",
+                    original=Original(string="a='b\\\\\\'c'", line=1),
+                    error=False,
+                )
+            ],
+        ),
+        (
             "a=à",
             [
                 Binding(


### PR DESCRIPTION
Fixes #661.

## Problem

`set_key` writes single-quoted values and escapes single quotes, but not backslashes. The single-quoted-value parser decodes `\` and `\'`, so a value containing a backslash does not survive a write/read round-trip:

```python
>>> dotenv.set_key(".env", "PATH", r"C:\Users")   # file gets PATH='C:\Users'
>>> dotenv.get_key(".env", "PATH")
'C:Users'
>>> dotenv.set_key(".env", "RE", r"\d+")
>>> dotenv.get_key(".env", "RE")
'd+'
```

Windows paths and regular expressions are the common victims.

## Fix, part 1 — escape on write

`value_to_set.replace("\\", "\\\\").replace("'", "\'")`. Backslashes first, so the backslash introduced by the quote escaping is not escaped again.

## Fix, part 2 — the write side alone is not enough

With only part 1, a value ending in a backslash is still broken, and breaks its neighbours too:

```
A='back\'
B='sentinel'
```

`_single_quoted_value` was `'((?:\'|[^'])*)'` — it knows `\'` is an escape but not `\`. So in `back\'` the second backslash pairs with the closing quote as `\'`, the match keeps going, and since `[^']` also matches newlines it runs into the next line. The binding then fails `_end_of_line`, error recovery kicks in, and `B` is lost as well.

Both quoted-value patterns now say "a backslash escapes the next character":

```python
_single_quoted_value = make_regex(r"'((?:\.|[^'\])*)'", extra_flags=re.DOTALL)
_double_quoted_value = make_regex(r'"((?:\.|[^"\])*)"', extra_flags=re.DOTALL)
```

`re.DOTALL` keeps multi-line quoted values working, which the old `[^']` allowed.

This is not a behaviour change for anything that parsed correctly before — the captured group is identical for every input the old pattern handled, and `decode_escapes` is untouched. It only changes inputs that previously failed to parse. Hand-written `A='C:\Users\name'` still yields `C:\Users\name`, and `A='b\'c'` still yields `b'c`.

## Tests

- `test_set_key` gains three cases pinning the written form for `b\c`, `b\` and `b\'c`.
- New `test_set_key_round_trips` parametrizes ten values (Windows paths with and without a trailing separator, regexes, quotes, empty) and asserts both that the value comes back intact and that a following key is still readable — that second assertion is what catches the line-swallowing.
- `test_parse_stream` gains five cases for escaped backslashes in both quote styles, including the two-binding case.

`pytest tests/` passes. The two `test_cli.py::test_run_*` failures on my machine are pre-existing and Windows-specific (they reproduce on an unmodified checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)