### PR TITLE
docs: update permanently moved links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,13 +235,13 @@ values defined in the following list:
 
 - [environs](https://github.com/sloria/environs)
 - [Honcho](https://github.com/nickstenning/honcho)
-- [dump-env](https://github.com/sobolevn/dump-env)
+- [dump-env](https://github.com/wemake-services/dump-env)
 - [dynaconf](https://github.com/dynaconf/dynaconf)
 - [parse_it](https://github.com/naorlivne/parse_it)
 - [django-dotenv](https://github.com/jpadilla/django-dotenv)
 - [django-environ](https://github.com/joke2k/django-environ)
 - [python-decouple](https://github.com/HBNetwork/python-decouple)
-- [django-configuration](https://github.com/jezdez/django-configurations)
+- [django-configuration](https://github.com/jazzband/django-configurations)
 
 ## Acknowledgements
 


### PR DESCRIPTION
Two links in the related-projects list in `README.md` returned HTTP 301/308 redirects. Replaced them with the targets from the respective `Location` headers:

- `https://github.com/sobolevn/dump-env` -> `https://github.com/wemake-services/dump-env`
- `https://github.com/jezdez/django-configurations` -> `https://github.com/jazzband/django-configurations`

Files changed:
- `README.md`

Verification: documentation-only change. The project's build and test suite were not run.

---
Disclosure: this patch was prepared with AI assistance. I reviewed the
change before opening this PR.