### PR TITLE
Fix backslash round trips in set_key

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -216,7 +216,8 @@ def set_key(
     )
 
     if quote:
-        value_out = "'{}'".format(value_to_set.replace("'", "\\'"))
+        escaped_value = value_to_set.replace("\\", "\\\\").replace("'", "\\'")
+        value_out = f"'{escaped_value}'"
     else:
         value_out = value_to_set
     if export:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -63,6 +63,21 @@ def test_set_key_encoding(dotenv_path):
     assert dotenv_path.read_text(encoding=encoding) == "a='é'\n"
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "C:\\Users\\name",
+        r"\\d+",
+        r"prefix\\suffix",
+        "backslash\\'quote",
+    ],
+)
+def test_set_key_round_trips_backslashes(dotenv_path, value):
+    dotenv.set_key(dotenv_path, "VALUE", value)
+
+    assert dotenv.get_key(dotenv_path, "VALUE") == value
+
+
 @pytest.mark.skipif(
     sys.platform == "win32", reason="file mode bits behave differently on Windows"
 )


### PR DESCRIPTION
## Summary

- escape backslashes before serializing single-quoted values in `set_key`
- keep quote escaping behavior while making Windows paths, regexes, and repeated backslashes round-trip
- add regression coverage for paths, regexes, repeated backslashes, and adjacent quotes

## Root cause

`set_key` escaped only single quotes, while the single-quoted parser decodes both `\\` and `\'`. Consecutive backslashes were therefore collapsed when the file was read back.

## Tests

- `.venv-task/bin/ruff format --check src tests`
- `.venv-task/bin/ruff check .`
- `.venv-task/bin/pytest tests/test_main.py -q` (119 passed)
- `PATH="$PWD/.venv-task/bin:$PATH" .venv-task/bin/pytest -q --ignore=tests/test_cli.py` (187 passed)
- `PATH="$PWD/.venv-task/bin:$PATH" .venv-task/bin/pytest tests/test_cli.py -q -k "not test_run_with_command_flags"` (39 passed, 1 deselected)

The excluded CLI test invokes GNU-only `printenv --version`, which is unsupported by macOS BSD `printenv`; it is unrelated to this change.

Fixes #661
