### PR TITLE
Substitute ${name:-default} when the variable is set but empty (POSIX)

### DIFF
--- a/src/dotenv/variables.py
+++ b/src/dotenv/variables.py
@@ -62,8 +62,10 @@ class Variable(Atom):
         return hash((self.__class__, self.name, self.default))
 
     def resolve(self, env: Mapping[str, Optional[str]]) -> str:
-        default = self.default if self.default is not None else ""
-        result = env.get(self.name, default)
+        result = env.get(self.name)
+        if not result and self.default is not None:
+            # POSIX ${name:-default} substitutes when name is unset OR null.
+            return self.default
         return result if result is not None else ""
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -702,6 +702,11 @@ def test_dotenv_values_file(dotenv_path):
         # Undefined
         ({}, "a=${b}", True, {"a": ""}),
         ({}, "a=${b:-d}", True, {"a": "d"}),
+        # Defined but empty: POSIX ${name:-default} substitutes on null too
+        ({"b": ""}, "a=${b:-d}", True, {"a": "d"}),
+        ({}, "b=\na=${b:-d}", True, {"a": "d", "b": ""}),
+        ({"b": ""}, "a=${b}", True, {"a": ""}),
+        ({"b": ""}, "a=${b:-}", True, {"a": ""}),
         # With quotes
         ({"b": "c"}, 'a="${b}"', True, {"a": "c"}),
         ({"b": "c"}, "a='${b}'", True, {"a": "c"}),


### PR DESCRIPTION
The README says interpolation follows POSIX variable expansion. `${name:-word}` in POSIX substitutes `word` when `name` is unset **or null**, and this only handles unset:

```python
result = env.get(self.name, default)
```

`env.get` falls back only when the key is absent, so a variable that exists and is empty returns empty.

```
.env
  EMPTY=
  GREETING=${EMPTY:-fallback}

dotenv_values  ->  GREETING = ''
sh             ->  fallback
```

The unset case and the set-to-a-value case both already match, so this is the one branch that doesn't.

The change resolves the name first and falls back to the default when the result is empty, which leaves `${b}` with no default alone and keeps `${b:-}` empty.

Four cases added to the `test_dotenv_values_string_io` table. Two fail on main, the empty-with-a-default ones. The other two pin `${b}` and `${b:-}` on an empty value, which behave the same before and after. Tests go from 226 to 230 passing, with the same 12 pre-existing `test_cli.py` failures either way. Those are `FileNotFoundError` on subprocess spawning in my environment, not this path.

This changes behaviour. Anyone who wrote `${VAR:-default}` and relied on an empty `VAR` staying empty gets the default instead now. That's what POSIX and the README both describe, but it's a change, so it's your call whether it belongs in a minor release or wants a note.
