### PR TITLE
fix: don't leak or mask errors when rewrite cleanup fails on Windows

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -135,6 +135,25 @@ def get_key(
     return DotEnv(dotenv_path, verbose=True, encoding=encoding).get(key_to_get)
 
 
+def _discard_temp_file(path: pathlib.Path) -> None:
+    """
+    Delete `rewrite`'s temporary file, ignoring any failure to do so.
+
+    This runs while another exception is propagating, so it must not raise:
+    that error is the one worth reporting. On Windows, a file whose mode has
+    no owner-write bit carries the read-only attribute and can't be unlinked,
+    so the mode is reset before a second attempt.
+    """
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        try:
+            path.chmod(stat.S_IWRITE | stat.S_IREAD)
+            path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning("python-dotenv could not remove the temporary file %s", path)
+
+
 @contextmanager
 def rewrite(
     path: StrPath,
@@ -183,10 +202,10 @@ def rewrite(
 
             os.replace(dest_path, path)
         except BaseException:
-            dest_path.unlink(missing_ok=True)
+            _discard_temp_file(dest_path)
             raise
     else:
-        dest_path.unlink(missing_ok=True)
+        _discard_temp_file(dest_path)
         raise error from None
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 import io
 import logging
 import os
+import pathlib
 import stat
 import subprocess
 import sys
@@ -193,6 +194,44 @@ def test_set_key_permission_error(dotenv_path):
     else:
         dotenv_path.chmod(0o600)
     assert dotenv_path.read_text() == ""
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32" and os.geteuid() == 0,
+    reason="Root user can access files even with 000 permissions.",
+)
+def test_set_key_permission_error_leaves_no_temp_file(dotenv_path):
+    if sys.platform == "win32":
+        # On Windows, make file read-only
+        dotenv_path.chmod(stat.S_IREAD)
+    else:
+        # On Unix, remove all permissions
+        dotenv_path.chmod(0o000)
+
+    try:
+        with pytest.raises(PermissionError):
+            dotenv.set_key(dotenv_path, "a", "b")
+
+        assert list(dotenv_path.parent.glob(".tmp_*")) == []
+    finally:
+        # Restore permissions
+        if sys.platform == "win32":
+            dotenv_path.chmod(stat.S_IWRITE | stat.S_IREAD)
+        else:
+            dotenv_path.chmod(0o600)
+
+
+def test_rewrite_reports_original_error_when_cleanup_fails(dotenv_path):
+    replace_error = OSError("replace failed")
+
+    with mock.patch("dotenv.main.os.replace", side_effect=replace_error):
+        with mock.patch.object(
+            pathlib.Path, "unlink", side_effect=OSError("unlink failed")
+        ):
+            with pytest.raises(OSError) as excinfo:
+                dotenv.set_key(dotenv_path, "a", "b")
+
+    assert excinfo.value is replace_error
 
 
 def test_get_key_no_file(tmp_path):


### PR DESCRIPTION
When `set_key` or `unset_key` fails after `rewrite()` has restored the original file mode, the temporary file has already been `chmod`ed to that mode. On Windows a mode without the owner-write bit sets the read-only attribute, so the `os.unlink` in the cleanup path fails too. The `.tmp_*` file is left next to the user's `.env`, and the cleanup error replaces the real one in the traceback.

A read-only `.env` is the easiest way in:

```python
import os, stat
from dotenv import set_key

open(".env", "w").write("A=1\n")
os.chmod(".env", stat.S_IREAD)
set_key(".env", "B", "2")
```

Before, on Windows, that raises from `pathlib`'s `os.unlink` and the message names only a temp file the caller has never heard of, with `.tmp_*` left behind. After, it raises from `os.replace` with both paths in the message and nothing is left behind.

This keeps the existing behaviour that `set_key` on a read-only file raises `PermissionError` (`test_set_key_permission_error` covers it). That test was passing for the wrong reason on Windows: it caught the cleanup's error, not the one from `os.replace`. I have not tried to make the write succeed by clearing the read-only attribute, which seems like a separate call and against the intent of the mode-preservation work in 790c5c0.

Two tests: one asserts no temp file survives the failure, one mocks `os.replace` and `Path.unlink` to assert a cleanup failure cannot stand in for the original error. The second is platform-independent; the first bites on Windows, where CI covers 3.10 and 3.14.

Found while looking into #554. That report cites the old `shutil.move` call, which 790c5c0 already replaced with `os.replace`, and I could not reproduce its symptom on a native Windows host. This is a different bug in the same function.
