### PR TITLE
Stop installing the dotenv console script on a plain pip install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- The `dotenv` console script is no longer installed with the base package. A
+  conda/venv `python-dotenv` without `[cli]` was dropping a stub `dotenv` on
+  `PATH` that hid a working user-level `[cli]` install. Run the CLI with
+  `python -m dotenv` after `pip install "python-dotenv[cli]"`. ([#683](https://github.com/theskumar/python-dotenv/issues/683))
+
 ### Fixed
 
 - An unquoted empty value followed by an inline comment (e.g. `KEY= # comment`) is now parsed as an empty string instead of the comment text by [@Noethix55555] in [#663]

--- a/README.md
+++ b/README.md
@@ -146,25 +146,26 @@ production.
 
 ## Command-line Interface
 
-A CLI interface `dotenv` is also included, which helps you manipulate the `.env`
-file without manually opening it.
+Install the `[cli]` extra and run it as a module. The package no longer
+installs a `dotenv` console script, so a bare install cannot shadow another
+environment's CLI.
 
 ```shell
 $ pip install "python-dotenv[cli]"
-$ dotenv set USER foo
-$ dotenv set EMAIL foo@example.org
-$ dotenv list
+$ python -m dotenv set USER foo
+$ python -m dotenv set EMAIL foo@example.org
+$ python -m dotenv list
 USER=foo
 EMAIL=foo@example.org
-$ dotenv list --format=json
+$ python -m dotenv list --format=json
 {
   "USER": "foo",
   "EMAIL": "foo@example.org"
 }
-$ dotenv run -- python foo.py
+$ python -m dotenv run -- python foo.py
 ```
 
-Run `dotenv --help` for more information about the options and subcommands.
+Run `python -m dotenv --help` for more information about the options and subcommands.
 
 ## File format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,6 @@ cli = [
     "click>=5.0",
 ]
 
-[project.scripts]
-dotenv = "dotenv.__main__:cli"
-
 [tool.setuptools]
 packages = ["dotenv"]
 package-dir = {"" = "src"}

--- a/src/dotenv/__main__.py
+++ b/src/dotenv/__main__.py
@@ -3,4 +3,4 @@
 from .cli import cli
 
 if __name__ == "__main__":
-    cli()
+    cli(prog_name="dotenv")

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,6 +1,10 @@
+import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import Sequence
+
+_SRC = str(Path(__file__).resolve().parents[1] / "src")
 
 
 def run_dotenv(
@@ -12,12 +16,16 @@ def run_dotenv(
     Run the `dotenv` CLI in a subprocess with the given arguments.
     """
 
+    run_env = {**os.environ, **(env or {})}
+    existing = run_env.get("PYTHONPATH", "")
+    run_env["PYTHONPATH"] = _SRC if not existing else f"{_SRC}{os.pathsep}{existing}"
+
     process = subprocess.run(
-        ["dotenv", *args],
+        [sys.executable, "-m", "dotenv", *args],
         capture_output=True,
         text=True,
         cwd=cwd,
-        env=env,
+        env=run_env,
     )
 
     return process


### PR DESCRIPTION
The `[cli]` extra is supposed to be what gives you the CLI, but the wheel always installed a `dotenv` script. That script then died with "not installed with cli option" if click wasn't in that environment.

In the setup from #683 that's the conda env's stub winning over a user-level `python-dotenv[cli]`. Pip installs the same wheel for both extras, so the script cannot actually be extra-gated. Dropping it from the base package and using `python -m dotenv` (after `pip install python-dotenv[cli]`) is the option that doesn't leave a fake command on PATH.

`__main__.py` still reports itself as `dotenv` so `--version` output stays the same.

Fixes #683
