### PR TITLE
fix: do not read through a symlink when rewriting a .env file

### DIFF
--- a/src/dotenv/main.py
+++ b/src/dotenv/main.py
@@ -1,3 +1,4 @@
+import errno
 import io
 import logging
 import os
@@ -135,6 +136,22 @@ def get_key(
     return DotEnv(dotenv_path, verbose=True, encoding=encoding).get(key_to_get)
 
 
+# `O_NOFOLLOW` is POSIX-only; on platforms without it the flag is a no-op and
+# `rewrite` falls back to the previous behaviour.
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+
+# Errors a platform may raise when `O_NOFOLLOW` refuses to open a symlink.
+_SYMLINK_ERRNOS = frozenset(
+    e
+    for e in (getattr(errno, "ELOOP", None), getattr(errno, "EMLINK", None))
+    if e is not None
+)
+
+
+def _opener_no_follow(file: str, flags: int) -> int:
+    return os.open(file, flags | _O_NOFOLLOW)
+
+
 @contextmanager
 def rewrite(
     path: StrPath,
@@ -145,7 +162,14 @@ def rewrite(
         path = os.path.realpath(path)
 
     try:
-        source: IO[str] = open(path, encoding=encoding)
+        # Do not read through a symlink unless asked to: `os.replace` below
+        # replaces the link itself rather than its target, so the target's
+        # contents are not the contents of the file being written.
+        source: IO[str] = open(
+            path,
+            encoding=encoding,
+            opener=None if follow_symlinks else _opener_no_follow,
+        )
         try:
             path_stat = os.lstat(path)
             original_mode: Optional[int] = (
@@ -157,6 +181,13 @@ def rewrite(
             source.close()
             raise
     except FileNotFoundError:
+        source = io.StringIO("")
+        original_mode = None
+    except OSError as exc:
+        if exc.errno not in _SYMLINK_ERRNOS:
+            raise
+        # The path is a symlink and we are not following it, so there is no
+        # existing content to carry over into its replacement.
         source = io.StringIO("")
         original_mode = None
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -129,16 +129,19 @@ def test_rewrite_closes_file_handle_on_lstat_failure(tmp_path):
     sys.platform == "win32", reason="symlinks require elevated privileges on Windows"
 )
 def test_set_key_symlink_to_existing_file(tmp_path):
+    # The target holds a different key from the one being set, so that content
+    # read through the symlink would be visible in the result rather than
+    # overwritten by the assignment.
     target = tmp_path / "target.env"
-    target.write_text("a=x\n")
+    target.write_text("b=x\n")
     symlink = tmp_path / ".env"
     symlink.symlink_to(target)
 
     dotenv.set_key(symlink, "a", "y")
 
-    assert target.read_text() == "a=x\n"
+    assert target.read_text() == "b=x\n"
     assert not symlink.is_symlink()
-    assert "a='y'" in symlink.read_text()
+    assert symlink.read_text() == "a='y'\n"
     assert stat.S_IMODE(symlink.stat().st_mode) == 0o600
 
 
@@ -321,14 +324,16 @@ def test_unset_non_existent_file(tmp_path):
     sys.platform == "win32", reason="symlinks require elevated privileges on Windows"
 )
 def test_unset_key_symlink_to_existing_file(tmp_path):
+    # As above, the target holds a different key from the one being unset, so
+    # that content read through the symlink would remain visible in the result.
     target = tmp_path / "target.env"
-    target.write_text("a=x\n")
+    target.write_text("b=x\n")
     symlink = tmp_path / ".env"
     symlink.symlink_to(target)
 
     dotenv.unset_key(symlink, "a")
 
-    assert target.read_text() == "a=x\n"
+    assert target.read_text() == "b=x\n"
     assert not symlink.is_symlink()
     assert symlink.read_text() == ""
 


### PR DESCRIPTION
## Description

`rewrite()` no longer follows symlinks when it replaces a `.env` file, but it
still opens the path for reading with `open()`, which does follow them. When the
path is a symlink, the target's contents are read and carried into the regular
file that replaces the link:

```python
>>> import os, tempfile, dotenv
>>> d = tempfile.mkdtemp()
>>> open(f"{d}/target.env", "w").write("SECRET=classified\n")
>>> os.symlink(f"{d}/target.env", f"{d}/.env")
>>> dotenv.set_key(f"{d}/.env", "a", "y")
>>> print(open(f"{d}/.env").read())
SECRET=classified
a='y'
```

`unset_key` behaves the same way.

To be clear about what this is not: the target file is never modified, so this
is not the file-overwrite problem fixed in 1.2.2, and the replacement file is
created with mode `0600`, so it is not readable by another user. It is a
narrower mismatch between what the rewrite says it does and what it does. The
1.2.2 change described itself as "`set_key` and `unset_key` used to follow
symlinks in some situations. This is no longer the case", and `os.replace()`
replaces the link rather than its target, so the target's contents are not the
contents of the file being written.

### The fix

Open the source with `O_NOFOLLOW` unless `follow_symlinks=True`, and treat the
resulting error the way a missing file is already treated: a symlink that is not
being followed has no existing content to carry over into its replacement.

`O_NOFOLLOW` is POSIX only. Where it is unavailable the flag is a no-op and
behaviour is unchanged, which is why the platform errno set is built defensively
rather than assumed.

This is a behaviour change in the same sense the 1.2.2 notes used: a `.env` that
is a symlink to a file with other keys will now be replaced by a file containing
only what was written, rather than the target's keys plus what was written.

### Why the existing tests did not catch it

`test_set_key_symlink_to_existing_file` and
`test_unset_key_symlink_to_existing_file` both used a target whose only key was
the key being set or unset, so anything read through the link was overwritten by
the operation and never visible. The `set_key` test also asserted with `in`
rather than `==`, which tolerated extra content.

Both now put a different key in the target and assert exact contents, so they
fail against the previous behaviour and pass with this change.

### Validation

`pytest`: 252 passed, 1 skipped. `ruff check src tests` and
`ruff format --check src tests` clean. `mypy src tests` reports no issues on
each of the versions the lint environment checks, 3.10 through 3.14.