### PR TITLE
Add support for Python 3.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,13 +26,13 @@ jobs:
         os:
           - ubuntu-latest
         python-version:
-          ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", pypy3.11]
+          ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t", pypy3.11]
         include:
           # Windows: Test lowest and highest supported Python versions
           - os: windows-latest
             python-version: "3.10"
           - os: windows-latest
-            python-version: "3.14"
+            python-version: "3.15"
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Support for Python 3.15, including the free-threaded (3.15t) build.
+
 ### Fixed
 
 - An unquoted empty value followed by an inline comment (e.g. `KEY= # comment`) is now parsed as an empty string instead of the comment text by [@Noethix55555] in [#663]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py{310,311,312,313,314,314t},pypy3,manifest,coverage-report
+envlist = lint,py{310,311,312,313,314,314t,315,315t},pypy3,manifest,coverage-report
 
 [gh-actions]
 python =
@@ -9,6 +9,8 @@ python =
     3.13: py313, lint, manifest
     3.14: py314
     3.14t: py314t
+    3.15: py315
+    3.15t: py315t
     pypy-3.11: pypy3
 
 [testenv]
@@ -16,10 +18,10 @@ deps =
     pytest
     pytest-cov
     click
-    py{310,311,312,313,314,314t,pypy3}: ipython
+    py{310,311,312,313,314,314t,315,315t,pypy3}: ipython
 commands = pytest --cov --cov-report=term-missing {posargs}
 depends =
-    py{310,311,312,313,314,314t},pypy3: coverage-clean
+    py{310,311,312,313,314,314t,315,315t},pypy3: coverage-clean
     coverage-report: py{310,311,312,313,314,314t},pypy3
 
 [testenv:lint]
@@ -30,6 +32,7 @@ deps =
 commands =
     ruff check src tests
     ruff format --check src tests
+    mypy --python-version=3.15 src tests
     mypy --python-version=3.14 src tests
     mypy --python-version=3.13 src tests
     mypy --python-version=3.12 src tests


### PR DESCRIPTION
Python 3.15 has reached the "release candidate" phase, meaning that the ABI and language APIs are now stable. We can now test under it and declare support for it :)

I ran tests locally; all relevant pass

```
  py315: OK (4.06 seconds)
  py315t: OK (3.06 seconds)
  lint: OK (1.20 seconds)
  congratulations :) (8.36 seconds)
```