### PR TITLE
Fix variable expansion in dotenv run --no-override

### DIFF
--- a/src/dotenv/cli.py
+++ b/src/dotenv/cli.py
@@ -17,7 +17,7 @@ except ImportError:
     )
     sys.exit(1)
 
-from .main import dotenv_values, set_key, unset_key
+from .main import DotEnv, dotenv_values, set_key, unset_key
 from .version import __version__
 
 
@@ -190,7 +190,7 @@ def run(ctx: click.Context, override: bool, commandline: tuple[str, ...]) -> Non
         )
     dotenv_as_dict = {
         k: v
-        for (k, v) in dotenv_values(file).items()
+        for (k, v) in DotEnv(file, override=override, encoding="utf-8").dict().items()
         if v is not None and (override or k not in os.environ)
     }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -209,6 +210,39 @@ def test_run_with_existing_variable_not_overridden(tmp_path):
     )
 
     check_process(result, exit_code=0, stdout="C\n")
+
+
+@pytest.mark.parametrize("options", [[], ["--override"], ["--no-override"]])
+@pytest.mark.parametrize("existing_value", [None, "environment", ""])
+def test_run_interpolation_respects_override(tmp_path, options, existing_value):
+    (tmp_path / ".env").write_text(
+        "DOTENV_TEST_BASE=file\nDOTENV_TEST_DERIVED=${DOTENV_TEST_BASE}/suffix\n"
+    )
+    env = dict(os.environ)
+    env.pop("DOTENV_TEST_BASE", None)
+    env.pop("DOTENV_TEST_DERIVED", None)
+    if existing_value is not None:
+        env["DOTENV_TEST_BASE"] = existing_value
+
+    result = run_dotenv(
+        [
+            "run",
+            *options,
+            sys.executable,
+            "-c",
+            "import os; print(os.environ['DOTENV_TEST_BASE']); "
+            "print(os.environ['DOTENV_TEST_DERIVED'])",
+        ],
+        cwd=tmp_path,
+        env=env,
+    )
+
+    expected = (
+        existing_value
+        if options == ["--no-override"] and existing_value is not None
+        else "file"
+    )
+    check_process(result, exit_code=0, stdout=f"{expected}\n{expected}/suffix\n")
 
 
 def test_run_with_none_value(tmp_path):


### PR DESCRIPTION
Fixes #697.

With `dotenv run --no-override`, a variable keeps its existing environment value, but references to it still expand using the value in `.env`. For example, the child process can receive `BASE=environment` alongside `DERIVED=file/suffix`.

This change passes the CLI's `override` option to `DotEnv`, which already handles both expansion orders. References now use the same precedence as the variables passed to the child process.

The regression test launches a real child process and checks both values. It covers the default mode, `--override`, and `--no-override`, with the existing variable absent, nonempty, or empty. The two conflicting `--no-override` cases fail without the fix.

Validation: 214 tests passed and 50 were skipped on Windows with Python 3.13.15. The existing tests need `printenv`, so Git for Windows' `usr/bin` was included in the test process PATH. All nine upstream CI jobs also passed on Linux and Windows.


